### PR TITLE
feat: add integration testing support with WebApplicationFactory

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,6 +19,8 @@
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.23.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageVersion Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />

--- a/hive.core/src/Hive.Abstractions/IMicroService.cs
+++ b/hive.core/src/Hive.Abstractions/IMicroService.cs
@@ -86,9 +86,31 @@ public interface IMicroService
 
   /// <summary>
   /// Method to asynchonoously initialize and start the microservice.
+  /// Blocks until the microservice stops.
   /// </summary>
   /// <param name="configuration"></param>
   /// <param name="args"></param>
   /// <returns>Exit code</returns>
   Task<int> RunAsync(IConfigurationRoot configuration = default!, params string[] args);
+
+  /// <summary>
+  /// Method to asynchronously initialize the microservice without starting it.
+  /// </summary>
+  /// <param name="configuration"></param>
+  /// <param name="args"></param>
+  /// <returns>Task</returns>
+  Task InitializeAsync(IConfigurationRoot? configuration = null, params string[] args);
+
+  /// <summary>
+  /// Method to asynchronously start the microservice after initialization.
+  /// Returns immediately after starting (does not block like RunAsync).
+  /// </summary>
+  /// <returns>Task that completes when the host has started</returns>
+  Task StartAsync();
+
+  /// <summary>
+  /// Method to asynchronously stop the microservice.
+  /// </summary>
+  /// <returns>Task that completes when the host has stopped</returns>
+  Task StopAsync();
 }

--- a/hive.microservices/src/Hive.MicroServices/Lifecycle/StartupService.cs
+++ b/hive.microservices/src/Hive.MicroServices/Lifecycle/StartupService.cs
@@ -13,6 +13,7 @@ public class StartupService : IHostedService
   private readonly IHostApplicationLifetime lifetime;
   private readonly ILogger<StartupService> logger;
   private readonly IMicroService service;
+  private readonly IServiceProvider serviceProvider;
 
   /// <summary>
   /// Initializes a new instance of the <see cref="StartupService"/> class.
@@ -20,11 +21,13 @@ public class StartupService : IHostedService
   /// <param name="service"></param>
   /// <param name="lifetime"></param>
   /// <param name="logger"></param>
-  public StartupService(IMicroService service, IHostApplicationLifetime lifetime, ILogger<StartupService> logger)
+  /// <param name="serviceProvider"></param>
+  public StartupService(IMicroService service, IHostApplicationLifetime lifetime, ILogger<StartupService> logger, IServiceProvider serviceProvider)
   {
     this.service = service ?? throw new ArgumentNullException(nameof(service));
     this.lifetime = lifetime ?? throw new ArgumentNullException(nameof(lifetime));
     this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    this.serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
   }
 
   /// <summary>
@@ -69,7 +72,7 @@ public class StartupService : IHostedService
   private async Task ExecuteHostedStartupServices()
   {
     var svc = (MicroService)service;
-    var svcs = svc.Host.Services.GetServices<IHostedStartupService>();
+    var svcs = serviceProvider.GetServices<IHostedStartupService>();
 
     try
     {

--- a/hive.microservices/tests/Hive.MicroServices.Tests/Hive.MicroServices.Tests.csproj
+++ b/hive.microservices/tests/Hive.MicroServices.Tests/Hive.MicroServices.Tests.csproj
@@ -8,6 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/hive.microservices/tests/Hive.MicroServices.Tests/MicroServiceTests.Startup.cs
+++ b/hive.microservices/tests/Hive.MicroServices.Tests/MicroServiceTests.Startup.cs
@@ -43,6 +43,7 @@ public partial class MicroServiceTests
     public async Task GivenRunAsyncIsInvoked_WhenNoIHostedStartupServicesAreUsed_ThenServiceShouldStartImmediately()
     {
       // Arrange
+      using var portScope = TestPortProvider.GetAvailableServicePortScope(5000, out var port);
       var config = new ConfigurationBuilder().Build();
 
       var service = new MicroService(ServiceName, new NullLogger<IMicroService>())
@@ -64,6 +65,7 @@ public partial class MicroServiceTests
     public async Task GivenRunAsyncIsInvoked_WhenNonFailingIHostedStartupServicesAreUsed_ThenServiceShouldStart()
     {
       // Arrange
+      using var portScope = TestPortProvider.GetAvailableServicePortScope(5000, out var port);
       var config = new ConfigurationBuilder().Build();
 
       var service = new MicroService(ServiceName, new NullLogger<IMicroService>())
@@ -90,6 +92,7 @@ public partial class MicroServiceTests
     public async Task GivenRunAsyncIsInvoked_WhenFailingIHostedStartupServicesAreUsed_ThenServiceShouldFailToStart()
     {
       // Arrange
+      using var portScope = TestPortProvider.GetAvailableServicePortScope(5000, out var port);
       var config = new ConfigurationBuilder().Build();
 
       var service = new MicroService(ServiceName, new NullLogger<IMicroService>())

--- a/hive.microservices/tests/Hive.MicroServices.Tests/MicroServiceTests.WebApplicationFactory.cs
+++ b/hive.microservices/tests/Hive.MicroServices.Tests/MicroServiceTests.WebApplicationFactory.cs
@@ -1,0 +1,142 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Hive.MicroServices.Api;
+using Hive.Testing;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Hive.MicroServices.Tests;
+
+public partial class MicroServiceTests
+{
+  public class WebHostIntegration
+  {
+    private const string ServiceName = "microservice-webhost-tests";
+
+    [Fact]
+    [IntegrationTest]
+    public async Task GivenMicroServiceWithConfigureWebHost_WhenCreatingTestServer_ThenServerUsesHiveConfiguration()
+    {
+      // Arrange
+      var config = new ConfigurationBuilder().Build();
+
+      var microservice = new MicroService(ServiceName, new NullLogger<IMicroService>())
+        .ConfigureApiPipeline(endpoints =>
+        {
+          endpoints.MapGet("/api/test", () => Results.Ok(new { message = "Hello from Hive" }));
+        })
+        .UseTestHost();
+
+      // Act - Initialize and start using IMicroService APIs
+      await microservice.InitializeAsync(config);
+      await microservice.StartAsync();
+
+      var server = ((MicroService)microservice).Host.GetTestServer();
+      var client = server.CreateClient();
+      var response = await client.GetAsync("/api/test");
+
+      // Assert
+      response.StatusCode.Should().Be(HttpStatusCode.OK);
+      var content = await response.Content.ReadAsStringAsync();
+      content.Should().Contain("Hello from Hive");
+
+      // Cleanup
+      await microservice.StopAsync();
+    }
+
+    [Fact]
+    [IntegrationTest]
+    public async Task GivenMicroServiceWithMultipleEndpoints_WhenMakingRequests_ThenAllEndpointsRespond()
+    {
+      // Arrange
+      var config = new ConfigurationBuilder().Build();
+
+      var microservice = new MicroService(ServiceName, new NullLogger<IMicroService>())
+        .ConfigureApiPipeline(endpoints =>
+        {
+          endpoints.MapGet("/api/users", () => Results.Ok(new[] { "Alice", "Bob" }));
+          endpoints.MapGet("/api/products", () => Results.Ok(new[] { "Product1", "Product2" }));
+          endpoints.MapPost("/api/orders", () => Results.Created("/api/orders/1", new { id = 1, status = "created" }));
+        })
+        .UseTestHost();
+
+      // Act - Initialize and start using IMicroService APIs
+      await microservice.InitializeAsync(config);
+      await microservice.StartAsync();
+
+      var server = ((MicroService)microservice).Host.GetTestServer();
+      var client = server.CreateClient();
+
+      // Act & Assert - GET /api/users
+      var usersResponse = await client.GetAsync("/api/users");
+      usersResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+      var usersContent = await usersResponse.Content.ReadAsStringAsync();
+      usersContent.Should().Contain("Alice");
+
+      // Act & Assert - GET /api/products
+      var productsResponse = await client.GetAsync("/api/products");
+      productsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+      var productsContent = await productsResponse.Content.ReadAsStringAsync();
+      productsContent.Should().Contain("Product1");
+
+      // Act & Assert - POST /api/orders
+      var ordersResponse = await client.PostAsync("/api/orders", null);
+      ordersResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+      var ordersContent = await ordersResponse.Content.ReadAsStringAsync();
+      ordersContent.Should().Contain("created");
+
+      // Cleanup
+      await microservice.StopAsync();
+    }
+
+    [Fact]
+    [IntegrationTest]
+    public async Task GivenMicroServiceWithCustomConfiguration_WhenAccessingEndpoints_ThenConfigurationIsApplied()
+    {
+      // Arrange
+      var config = new ConfigurationBuilder()
+        .AddInMemoryCollection(new Dictionary<string, string?>
+        {
+          ["AppName"] = "TestApp"
+        })
+        .Build();
+
+      var microservice = new MicroService(ServiceName, new NullLogger<IMicroService>())
+        .ConfigureServices((services, cfg) =>
+        {
+          // Configuration is available here via cfg parameter
+        })
+        .ConfigureApiPipeline(endpoints =>
+        {
+          endpoints.MapGet("/api/config", (IConfiguration configuration) =>
+            Results.Ok(new { appName = configuration["AppName"] }));
+        })
+        .UseTestHost();
+
+      // Act - Initialize and start using IMicroService APIs
+      await microservice.InitializeAsync(config);
+      await microservice.StartAsync();
+
+      var server = ((MicroService)microservice).Host.GetTestServer();
+      var client = server.CreateClient();
+      var response = await client.GetAsync("/api/config");
+
+      // Assert
+      response.StatusCode.Should().Be(HttpStatusCode.OK);
+      var content = await response.Content.ReadAsStringAsync();
+      content.Should().Contain("TestApp");
+
+      // Cleanup
+      await microservice.StopAsync();
+    }
+  }
+}

--- a/hive.microservices/tests/Hive.MicroServices.Tests/TestingExtensions/IMicroServiceTestingExtensions.cs
+++ b/hive.microservices/tests/Hive.MicroServices.Tests/TestingExtensions/IMicroServiceTestingExtensions.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace Hive.MicroServices;
+
+/// <summary>
+/// Testing extension methods for <see cref="IMicroService"/>
+/// </summary>
+public static class IMicroServiceTestingExtensions
+{
+  /// <summary>
+  /// Prepares the microservice to use a TestServer-based external host.
+  /// The host will be created during InitializeAsync with the configuration provided there.
+  /// After calling this method, use microservice.InitializeAsync(config) to build and initialize the host,
+  /// then microservice.StartAsync() to start it.
+  /// </summary>
+  /// <param name="microservice">The microservice instance</param>
+  /// <returns>The microservice instance for fluent chaining</returns>
+  /// <exception cref="ArgumentNullException">Thrown when microservice is null</exception>
+  public static IMicroService UseTestHost(this IMicroService microservice)
+  {
+    _ = microservice ?? throw new ArgumentNullException(nameof(microservice));
+
+    // Set a factory that will be called during InitializeAsync with the configuration
+    return microservice.WithExternalHostFactory(config =>
+    {
+      var hostBuilder = new HostBuilder()
+        .ConfigureWebHost(webHostBuilder =>
+        {
+          webHostBuilder.UseTestServer();
+          microservice.ConfigureWebHost(webHostBuilder, config);
+        });
+
+      return hostBuilder.Build();
+    });
+  }
+}

--- a/hive.opentelemetry/tests/Hive.OpenTelemetry.Tests/E2E/LogEmissionTests.cs
+++ b/hive.opentelemetry/tests/Hive.OpenTelemetry.Tests/E2E/LogEmissionTests.cs
@@ -190,7 +190,7 @@ public class LogEmissionTests : E2ETestBase
       ServiceName,
       app => app.MapGet("/multiple-test", (ILogger<LogEmissionTests> logger) =>
       {
-        for (int i = 1; i <= 5; i++)
+        for (var i = 1; i <= 5; i++)
         {
           logger.LogInformation("Log message number {Number}", i);
         }

--- a/hive.opentelemetry/tests/Hive.OpenTelemetry.Tests/E2E/MetricsEmissionTests.cs
+++ b/hive.opentelemetry/tests/Hive.OpenTelemetry.Tests/E2E/MetricsEmissionTests.cs
@@ -54,7 +54,7 @@ public class MetricsEmissionTests : E2ETestBase
       using var client = CreateHttpClient();
 
       // Make multiple requests
-      for (int i = 0; i < 5; i++)
+      for (var i = 0; i < 5; i++)
       {
         await client.GetAsync("/accumulate-test");
       }


### PR DESCRIPTION
This commit introduces comprehensive integration testing capabilities:

- Add InitializeAsync, StartAsync, and StopAsync methods to IMicroService for granular lifecycle control
- Add WithExternalHost and WithExternalHostFactory extensions for test infrastructure integration
- Add ConfigureWebHost extension for seamless WebApplicationFactory integration
- Fix StartupService to prevent async-over-sync anti-pattern by accepting IServiceProvider
- Add Microsoft.AspNetCore.Mvc.Testing and TestHost packages for testing infrastructure
- Add WebApplicationFactory-based test helpers and MicroServiceTestingExtensions
- Add TestPortProvider usage to startup tests to prevent port conflicts
- Refactor loop variables to use 'var' for consistency

The new testing APIs enable:
- External control of microservice lifecycle (initialize, start, stop separately)
- Integration with ASP.NET Core's WebApplicationFactory
- TestServer-based testing while preserving all Hive configuration
- Improved test isolation and reliability