### PR TITLE
feat: add integration testing support with WebApplicationFactory

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,6 +19,8 @@
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.23.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageVersion Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />

--- a/Hive.sln
+++ b/Hive.sln
@@ -51,6 +51,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hive.MicroServices.Demo.Ser
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hive.OpenTelemetry.Tests", "hive.opentelemetry\tests\Hive.OpenTelemetry.Tests\Hive.OpenTelemetry.Tests.csproj", "{68CBA07C-6E5F-44DF-B056-919EBDE5009C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Hive.MicroServices.Testing", "hive.microservices\src\Hive.MicroServices.Testing\Hive.MicroServices.Testing.csproj", "{C22B628D-7E1D-4087-BC7D-53218C93C193}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -229,6 +231,18 @@ Global
 		{68CBA07C-6E5F-44DF-B056-919EBDE5009C}.Release|x64.Build.0 = Release|Any CPU
 		{68CBA07C-6E5F-44DF-B056-919EBDE5009C}.Release|x86.ActiveCfg = Release|Any CPU
 		{68CBA07C-6E5F-44DF-B056-919EBDE5009C}.Release|x86.Build.0 = Release|Any CPU
+		{C22B628D-7E1D-4087-BC7D-53218C93C193}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C22B628D-7E1D-4087-BC7D-53218C93C193}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C22B628D-7E1D-4087-BC7D-53218C93C193}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C22B628D-7E1D-4087-BC7D-53218C93C193}.Debug|x64.Build.0 = Debug|Any CPU
+		{C22B628D-7E1D-4087-BC7D-53218C93C193}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C22B628D-7E1D-4087-BC7D-53218C93C193}.Debug|x86.Build.0 = Debug|Any CPU
+		{C22B628D-7E1D-4087-BC7D-53218C93C193}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C22B628D-7E1D-4087-BC7D-53218C93C193}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C22B628D-7E1D-4087-BC7D-53218C93C193}.Release|x64.ActiveCfg = Release|Any CPU
+		{C22B628D-7E1D-4087-BC7D-53218C93C193}.Release|x64.Build.0 = Release|Any CPU
+		{C22B628D-7E1D-4087-BC7D-53218C93C193}.Release|x86.ActiveCfg = Release|Any CPU
+		{C22B628D-7E1D-4087-BC7D-53218C93C193}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -255,5 +269,6 @@ Global
 		{380C2A38-8424-49C2-B2F5-1CB532D5A3F8} = {91B02555-8919-4F8E-A3ED-9B73FA898067}
 		{0CCC05F9-6FA0-464F-9543-89923C52A338} = {91B02555-8919-4F8E-A3ED-9B73FA898067}
 		{68CBA07C-6E5F-44DF-B056-919EBDE5009C} = {092FBD16-5621-403E-AC2B-2AB1C9C6BA3F}
+		{C22B628D-7E1D-4087-BC7D-53218C93C193} = {DA6AB591-BEB6-4F6B-B8B9-847A1E75DC0C}
 	EndGlobalSection
 EndGlobal

--- a/Hive.sln.DotSettings.user
+++ b/Hive.sln.DotSettings.user
@@ -9,9 +9,6 @@
 &lt;/SessionState&gt;</s:String>
 	
 	
-	<s:Boolean x:Key="/Default/UnloadedProject/UnloadedProjects/=12425f6b_002Dc2ec_002D4111_002D956f_002D3bc7e20e3c3d_0023Hive_002EMicroServices_002EJob/@EntryIndexedValue">True</s:Boolean>
-	
-	<s:Boolean x:Key="/Default/UnloadedProject/UnloadedProjects/=359ad44b_002D855c_002D4cf7_002Da58c_002D23648225b8cb_0023Hive_002EMicroServices_002EGrpc/@EntryIndexedValue">True</s:Boolean>
 	
 	
 	
@@ -25,5 +22,8 @@
 	
 	
 	
-	<s:Boolean x:Key="/Default/UnloadedProject/UnloadedProjects/=efbf0b5f_002D644b_002D4565_002D846e_002D352e84561499_0023Hive_002EMicroServices_002EGraphQL/@EntryIndexedValue">True</s:Boolean>
+	
+	
+	
+	
 	</wpf:ResourceDictionary>

--- a/hive.core/src/Hive.Abstractions/IMicroService.cs
+++ b/hive.core/src/Hive.Abstractions/IMicroService.cs
@@ -86,9 +86,31 @@ public interface IMicroService
 
   /// <summary>
   /// Method to asynchonoously initialize and start the microservice.
+  /// Blocks until the microservice stops.
   /// </summary>
   /// <param name="configuration"></param>
   /// <param name="args"></param>
   /// <returns>Exit code</returns>
   Task<int> RunAsync(IConfigurationRoot configuration = default!, params string[] args);
+
+  /// <summary>
+  /// Method to asynchronously initialize the microservice without starting it.
+  /// </summary>
+  /// <param name="configuration"></param>
+  /// <param name="args"></param>
+  /// <returns>Task</returns>
+  Task InitializeAsync(IConfigurationRoot? configuration = null, params string[] args);
+
+  /// <summary>
+  /// Method to asynchronously start the microservice after initialization.
+  /// Returns immediately after starting (does not block like RunAsync).
+  /// </summary>
+  /// <returns>Task that completes when the host has started</returns>
+  Task StartAsync();
+
+  /// <summary>
+  /// Method to asynchronously stop the microservice.
+  /// </summary>
+  /// <returns>Task that completes when the host has stopped</returns>
+  Task StopAsync();
 }

--- a/hive.core/src/Hive.Abstractions/IMicroService.cs
+++ b/hive.core/src/Hive.Abstractions/IMicroService.cs
@@ -5,7 +5,7 @@ namespace Hive;
 /// <summary>
 /// The base IMicroService interface. All Hive microservices implement this interface.
 /// </summary>
-public interface IMicroService
+public interface IMicroService : IAsyncDisposable, IDisposable
 {
   /// <summary>
   /// The cancellation token source for the microservice
@@ -85,7 +85,7 @@ public interface IMicroService
   IMicroService RegisterExtension<TExtension>() where TExtension : MicroServiceExtension, new();
 
   /// <summary>
-  /// Method to asynchonoously initialize and start the microservice.
+  /// Method to asynchonously initialize and start the microservice.
   /// Blocks until the microservice stops.
   /// </summary>
   /// <param name="configuration"></param>

--- a/hive.core/src/Hive.Abstractions/IMicroServiceLifetime.cs
+++ b/hive.core/src/Hive.Abstractions/IMicroServiceLifetime.cs
@@ -3,7 +3,7 @@ namespace Hive;
 /// <summary>
 /// Interface for microservice lifetime events
 /// </summary>
-public interface IMicroServiceLifetime
+public interface IMicroServiceLifetime : IDisposable
 {
   /// <summary>
   /// One-time event indicating if the service has started

--- a/hive.microservices/README.md
+++ b/hive.microservices/README.md
@@ -1,0 +1,490 @@
+# Hive Microservices
+
+An opinionated, extensible microservices framework built on ASP.NET Core for building production-ready services with minimal boilerplate.
+
+## Overview
+
+The Hive Microservices module provides a comprehensive framework for building microservices in .NET 10. It follows a plugin-based architecture where all features are implemented as extensions to the core `IMicroService` abstraction, enabling clean separation of concerns and maximum flexibility.
+
+## Architecture
+
+```mermaid
+graph TB
+    subgraph Core
+        MicroServices[Hive.MicroServices]
+    end
+
+    subgraph "Pipeline Extensions"
+        Api[Hive.MicroServices.Api]
+        GraphQL[Hive.MicroServices.GraphQL]
+        Grpc[Hive.MicroServices.Grpc]
+        Job[Hive.MicroServices.Job]
+    end
+
+    subgraph Testing
+        Testing[Hive.MicroServices.Testing]
+    end
+
+    MicroServices -->|REST APIs| Api
+    MicroServices -->|GraphQL| GraphQL
+    MicroServices -->|gRPC| Grpc
+    MicroServices -->|Workers| Job
+    MicroServices -.->|Test Support| Testing
+
+    style MicroServices fill:#e1f5ff,stroke:#01579b,stroke-width:3px
+    style Api fill:#b3e5fc,stroke:#0277bd
+    style GraphQL fill:#b3e5fc,stroke:#0277bd
+    style Grpc fill:#b3e5fc,stroke:#0277bd
+    style Job fill:#b3e5fc,stroke:#0277bd
+    style Testing fill:#81d4fa,stroke:#0288d1
+```
+
+## Module Contents
+
+### Core Framework
+
+#### [Hive.MicroServices](src/Hive.MicroServices/)
+
+The foundation of all Hive microservices. Provides:
+- Core `MicroService` orchestration framework
+- Extension pattern infrastructure
+- Lifecycle management (Initialize → Start → Stop → Dispose)
+- Configuration management (pre/post-configuration patterns)
+- Kubernetes integration (startup, readiness, liveness probes)
+- Resource disposal patterns (IAsyncDisposable, IDisposable)
+
+**Key Features:**
+- Pipeline mode abstraction
+- Extension-based architecture
+- Built-in health checks
+- Comprehensive error handling
+- ASP.NET Core host integration
+
+📖 [Read Full Documentation](src/Hive.MicroServices/README.md)
+
+### Pipeline Extensions
+
+#### [Hive.MicroServices.Api](src/Hive.MicroServices.Api/)
+
+REST API support with both minimal APIs and controller-based approaches.
+
+**Capabilities:**
+- Minimal API endpoint routing
+- Traditional MVC controllers
+- Automatic service registration
+- API-specific middleware configuration
+
+**Use Cases:** REST APIs, HTTP microservices, web services
+
+---
+
+#### [Hive.MicroServices.GraphQL](src/Hive.MicroServices.GraphQL/)
+
+GraphQL API support powered by HotChocolate.
+
+**Capabilities:**
+- HotChocolate integration
+- Schema-first development
+- GraphQL-specific middleware
+- Subscription support
+
+**Use Cases:** GraphQL services, real-time data APIs, flexible query interfaces
+
+---
+
+#### [Hive.MicroServices.Grpc](src/Hive.MicroServices.Grpc/)
+
+gRPC service support with standard protobuf-first approach.
+
+**Capabilities:**
+- Standard gRPC services
+- Protobuf-first development
+- Code-first gRPC (optional)
+- Streaming support
+
+**Use Cases:** High-performance RPC, inter-service communication, streaming services
+
+---
+
+#### [Hive.MicroServices.Job](src/Hive.MicroServices.Job/)
+
+Background worker and scheduled job support.
+
+**Capabilities:**
+- Background service hosting
+- Scheduled task execution
+- Worker service patterns
+- Long-running processes
+
+**Use Cases:** Background workers, scheduled tasks, message processors, queue consumers
+
+### Testing Support
+
+#### [Hive.MicroServices.Testing](src/Hive.MicroServices.Testing/)
+
+Integration testing utilities using ASP.NET Core TestServer.
+
+**Capabilities:**
+- `ConfigureTestHost()` extension for in-memory testing
+- TestServer integration
+- Full Hive configuration preservation
+- Idempotent test setup
+
+**Benefits:**
+- Fast in-memory tests
+- No HTTP server overhead
+- Complete integration testing
+- Simple test setup
+
+📖 [Read Full Testing Guide](src/Hive.MicroServices.Testing/README.md)
+
+## Quick Start
+
+### Basic REST API
+
+```csharp
+using Hive;
+using Hive.MicroServices.Api;
+
+var microservice = new MicroService("my-api")
+    .ConfigureApiPipeline(endpoints =>
+    {
+        endpoints.MapGet("/health", () => Results.Ok("Healthy"));
+        endpoints.MapGet("/api/users", () => Results.Ok(new[] { "Alice", "Bob" }));
+    });
+
+await microservice.RunAsync();
+```
+
+### With Configuration and Services
+
+```csharp
+var config = new ConfigurationBuilder()
+    .AddJsonFile("appsettings.json")
+    .AddEnvironmentVariables()
+    .Build();
+
+var microservice = new MicroService("my-service")
+    .ConfigureServices((services, configuration) =>
+    {
+        services.AddSingleton<IUserService, UserService>();
+        services.ConfigureValidatedOptions<AppSettings>(
+            configuration.GetSection("App")
+        );
+    })
+    .ConfigureApiPipeline(endpoints =>
+    {
+        endpoints.MapGet("/api/users", async (IUserService userService) =>
+        {
+            var users = await userService.GetUsersAsync();
+            return Results.Ok(users);
+        });
+    });
+
+await microservice.RunAsync(config);
+```
+
+### Integration Testing
+
+```csharp
+using Hive.MicroServices.Api;
+using Hive.MicroServices.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Xunit;
+
+public class ApiTests
+{
+    [Fact]
+    public async Task GivenEndpoint_WhenCalled_ThenReturnsOk()
+    {
+        await using var microservice = new MicroService("test-service")
+            .ConfigureApiPipeline(endpoints =>
+            {
+                endpoints.MapGet("/api/test", () => Results.Ok("Success"));
+            })
+            .ConfigureTestHost();
+
+        await microservice.InitializeAsync(new ConfigurationBuilder().Build());
+        await microservice.StartAsync();
+
+        var server = ((MicroService)microservice).Host.GetTestServer();
+        var client = server.CreateClient();
+        var response = await client.GetAsync("/api/test");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await microservice.StopAsync();
+    }
+}
+```
+
+## Pipeline Modes
+
+Each extension configures a specific pipeline mode:
+
+| Extension | Pipeline Mode | Description |
+|-----------|--------------|-------------|
+| **Api** | `Api` | Minimal APIs with endpoint routing |
+| **Api** | `ApiControllers` | Traditional MVC controller-based APIs |
+| **GraphQL** | `GraphQL` | GraphQL APIs via HotChocolate |
+| **Grpc** | `Grpc` | gRPC services (protobuf-first) |
+| **Job** | `Job` | Background worker services |
+| - | `None` | Basic service without HTTP |
+
+## Extension Pattern
+
+All framework features follow a consistent extension pattern:
+
+```mermaid
+graph LR
+    MicroService[MicroService]
+    Extension[MicroServiceExtension]
+    Services[ConfigureServices]
+    Pipeline[Configure Pipeline]
+    Endpoints[ConfigureEndpoints]
+    Health[ConfigureHealthChecks]
+
+    MicroService -->|Hosts| Extension
+    Extension -->|1| Services
+    Extension -->|2| Pipeline
+    Extension -->|3| Endpoints
+    Extension -->|4| Health
+
+    style MicroService fill:#e1f5ff
+    style Extension fill:#b3e5fc
+    style Services fill:#81d4fa
+    style Pipeline fill:#81d4fa
+    style Endpoints fill:#81d4fa
+    style Health fill:#81d4fa
+```
+
+### Creating Custom Extensions
+
+```csharp
+public class MyCustomExtension : MicroServiceExtension
+{
+    public MyCustomExtension(IMicroService microService) : base(microService)
+    {
+    }
+
+    public override void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddSingleton<IMyService, MyService>();
+    }
+
+    public override void Configure(IApplicationBuilder app)
+    {
+        app.UseMiddleware<MyCustomMiddleware>();
+    }
+
+    public override void ConfigureEndpoints(IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/custom", () => "Custom endpoint");
+    }
+}
+
+// Usage
+var microservice = new MicroService("my-service")
+    .RegisterExtension<MyCustomExtension>()
+    .ConfigureApiPipeline(endpoints => { /* ... */ });
+```
+
+## Lifecycle
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant MicroService
+    participant Extensions
+    participant Host
+
+    User->>MicroService: new MicroService(name)
+    User->>MicroService: Configure*() / RegisterExtension()
+
+    User->>MicroService: InitializeAsync(config)
+    MicroService->>Extensions: ConfigureServices()
+    MicroService->>Host: Build Host
+    MicroService-->>User: Ready to Start
+
+    User->>MicroService: StartAsync()
+    MicroService->>Host: StartAsync()
+    Host-->>MicroService: Started
+    MicroService-->>User: Running
+
+    Note over MicroService,Host: Service Running
+
+    User->>MicroService: StopAsync()
+    MicroService->>Host: StopAsync()
+
+    User->>MicroService: DisposeAsync()
+    MicroService->>Host: Dispose()
+    MicroService-->>User: Disposed
+```
+
+## Kubernetes Integration
+
+All Hive microservices include built-in Kubernetes probe endpoints:
+
+```yaml
+# Example Kubernetes configuration
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-microservice
+spec:
+  containers:
+  - name: app
+    image: my-microservice:latest
+    ports:
+    - containerPort: 8080
+    startupProbe:
+      httpGet:
+        path: /startup
+        port: 8080
+      failureThreshold: 30
+      periodSeconds: 10
+    livenessProbe:
+      httpGet:
+        path: /liveness
+        port: 8080
+      periodSeconds: 10
+    readinessProbe:
+      httpGet:
+        path: /readiness
+        port: 8080
+      periodSeconds: 5
+```
+
+## Demo Applications
+
+See complete examples in the [demo/](demo/) folder:
+
+- **[Hive.MicroServices.Demo.Api](demo/Hive.MicroServices.Demo.Api/)**: REST API demo
+- **[Hive.MicroServices.Demo.Aspire](demo/Hive.MicroServices.Demo.Aspire/)**: Aspire orchestration with all demos
+
+### Running Demos
+
+```bash
+# Run API demo
+dotnet run --project demo/Hive.MicroServices.Demo.Api
+
+# Run Aspire orchestration (all demos)
+dotnet run --project demo/Hive.MicroServices.Demo.Aspire
+```
+
+## Project Structure
+
+```
+hive.microservices/
+├── demo/                              # Demo applications
+│   ├── Hive.MicroServices.Demo.Api/
+│   ├── Hive.MicroServices.Demo.Aspire/
+│   └── Hive.MicroServices.Demo.ServiceDefaults/
+├── src/                               # Source code
+│   ├── Hive.MicroServices/           # Core framework
+│   ├── Hive.MicroServices.Api/       # REST API support
+│   ├── Hive.MicroServices.GraphQL/   # GraphQL support
+│   ├── Hive.MicroServices.Grpc/      # gRPC support
+│   ├── Hive.MicroServices.Job/       # Background job support
+│   └── Hive.MicroServices.Testing/   # Testing utilities
+└── tests/                             # Test projects
+    └── Hive.MicroServices.Tests/
+```
+
+## Dependencies
+
+### Core Dependencies
+- .NET 10.0
+- ASP.NET Core
+- Microsoft.Extensions.* (Hosting, DependencyInjection, Configuration)
+
+### Optional Dependencies (via extensions)
+- HotChocolate (GraphQL)
+- Grpc.AspNetCore (gRPC)
+- OpenTelemetry (Observability)
+
+## Related Projects
+
+### Within Hive Repository
+- **[Hive.Abstractions](../hive.core/src/Hive.Abstractions/)**: Core abstractions and interfaces
+- **[Hive.Testing](../hive.core/src/Hive.Testing/)**: Generic testing utilities
+- **[Hive.OpenTelemetry](../hive.opentelemetry/)**: OpenTelemetry integration
+
+### Dependency Graph
+
+```mermaid
+graph TB
+    Abstractions[Hive.Abstractions]
+    Testing[Hive.Testing]
+    MicroServices[Hive.MicroServices]
+    Api[Hive.MicroServices.Api]
+    GraphQL[Hive.MicroServices.GraphQL]
+    Grpc[Hive.MicroServices.Grpc]
+    Job[Hive.MicroServices.Job]
+    MSTesting[Hive.MicroServices.Testing]
+
+    Abstractions --> Testing
+    Abstractions --> MicroServices
+    MicroServices --> Api
+    MicroServices --> GraphQL
+    MicroServices --> Grpc
+    MicroServices --> Job
+    MicroServices --> MSTesting
+
+    style Abstractions fill:#e1f5ff
+    style Testing fill:#b3e5fc
+    style MicroServices fill:#81d4fa
+    style Api fill:#4fc3f7
+    style GraphQL fill:#4fc3f7
+    style Grpc fill:#4fc3f7
+    style Job fill:#4fc3f7
+    style MSTesting fill:#29b6f6
+```
+
+## Building and Testing
+
+### Build All Projects
+
+```bash
+# Using CloudTek.Build.Tool (recommended)
+dotnet tool run cloudtek-build --target All
+
+# Using dotnet CLI
+dotnet build Hive.sln
+```
+
+### Run Tests
+
+```bash
+# All tests
+dotnet test Hive.sln
+
+# Integration tests only
+dotnet test --filter Category=IntegrationTests
+
+# Unit tests only
+dotnet test --filter Category=UnitTests
+```
+
+## Package Information
+
+All packages are published to NuGet:
+
+| Package | Description | Version |
+|---------|-------------|---------|
+| `Hive.MicroServices` | Core framework | ![NuGet](https://img.shields.io/nuget/v/Hive.MicroServices) |
+| `Hive.MicroServices.Api` | REST API support | ![NuGet](https://img.shields.io/nuget/v/Hive.MicroServices.Api) |
+| `Hive.MicroServices.GraphQL` | GraphQL support | ![NuGet](https://img.shields.io/nuget/v/Hive.MicroServices.GraphQL) |
+| `Hive.MicroServices.Grpc` | gRPC support | ![NuGet](https://img.shields.io/nuget/v/Hive.MicroServices.Grpc) |
+| `Hive.MicroServices.Job` | Background jobs | ![NuGet](https://img.shields.io/nuget/v/Hive.MicroServices.Job) |
+| `Hive.MicroServices.Testing` | Testing utilities | ![NuGet](https://img.shields.io/nuget/v/Hive.MicroServices.Testing) |
+
+## Repository
+
+- **GitHub**: https://github.com/cloud-tek/hive
+- **License**: [Check repository]
+- **Target Framework**: .NET 10.0
+
+## Contributing
+
+This is part of the Hive monorepo. For contribution guidelines, see the [main repository](https://github.com/cloud-tek/hive).

--- a/hive.microservices/README.md
+++ b/hive.microservices/README.md
@@ -22,14 +22,14 @@ graph TB
     end
 
     subgraph Testing
-        Testing[Hive.MicroServices.Testing]
+        HTesting[Hive.MicroServices.Testing]
     end
 
     MicroServices -->|REST APIs| Api
     MicroServices -->|GraphQL| GraphQL
     MicroServices -->|gRPC| Grpc
     MicroServices -->|Workers| Job
-    MicroServices -.->|Test Support| Testing
+    MicroServices -.->|Test Support| HTesting
 
     style MicroServices fill:#e1f5ff,stroke:#01579b,stroke-width:3px
     style Api fill:#b3e5fc,stroke:#0277bd

--- a/hive.microservices/src/Hive.MicroServices.Testing/Hive.MicroServices.Testing.csproj
+++ b/hive.microservices/src/Hive.MicroServices.Testing/Hive.MicroServices.Testing.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>true</IsPackable>
+    <RepositoryUrl>https://github.com/cloud-tek/hive</RepositoryUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/cloud-tek/public/main/images/cloud-tek.png</PackageIconUrl>
+    <NoWarn>NU5048</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <IsTestProject>false</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Hive.MicroServices\Hive.MicroServices.csproj" />
+  </ItemGroup>
+</Project>

--- a/hive.microservices/src/Hive.MicroServices.Testing/IMicroServiceTestingExtensions.cs
+++ b/hive.microservices/src/Hive.MicroServices.Testing/IMicroServiceTestingExtensions.cs
@@ -1,9 +1,7 @@
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
-namespace Hive.MicroServices;
+namespace Hive.MicroServices.Testing;
 
 /// <summary>
 /// Testing extension methods for <see cref="IMicroService"/>

--- a/hive.microservices/src/Hive.MicroServices.Testing/README.md
+++ b/hive.microservices/src/Hive.MicroServices.Testing/README.md
@@ -1,0 +1,501 @@
+# Hive.MicroServices.Testing
+
+Integration testing utilities for Hive microservices using ASP.NET Core TestServer.
+
+## Overview
+
+`Hive.MicroServices.Testing` provides testing extensions that enable integration testing of Hive microservices using the ASP.NET Core TestServer infrastructure. This allows you to test your microservices in-memory without needing to start actual HTTP servers.
+
+## Architecture
+
+```mermaid
+graph TB
+    Test[xUnit Test]
+    Extension[ConfigureTestHost Extension]
+    MicroService[MicroService]
+    TestServer[ASP.NET TestServer]
+    HttpClient[HttpClient]
+
+    Test -->|Uses| Extension
+    Extension -->|Configures| MicroService
+    MicroService -->|Creates| TestServer
+    TestServer -->|Provides| HttpClient
+    Test -->|Makes Requests| HttpClient
+
+    style Test fill:#e1f5ff
+    style Extension fill:#b3e5fc
+    style MicroService fill:#81d4fa
+    style TestServer fill:#4fc3f7
+    style HttpClient fill:#29b6f6
+```
+
+## Installation
+
+Add the package reference to your test project:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Hive.MicroServices.Testing" />
+</ItemGroup>
+```
+
+## Basic Usage
+
+### Simple Integration Test
+
+```csharp
+using Hive.MicroServices.Api;
+using Hive.MicroServices.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+public class MyApiTests
+{
+    [Fact]
+    public async Task GivenEndpoint_WhenCalled_ThenReturnsOk()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder().Build();
+
+        await using var microservice = new MicroService("test-service")
+            .ConfigureApiPipeline(endpoints =>
+            {
+                endpoints.MapGet("/api/test", () => Results.Ok(new { message = "Hello" }));
+            })
+            .ConfigureTestHost();
+
+        // Act
+        await microservice.InitializeAsync(config);
+        await microservice.StartAsync();
+
+        var server = ((MicroService)microservice).Host.GetTestServer();
+        var client = server.CreateClient();
+        var response = await client.GetAsync("/api/test");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var content = await response.Content.ReadAsStringAsync();
+        content.Should().Contain("Hello");
+
+        // Cleanup
+        await microservice.StopAsync();
+    }
+}
+```
+
+## Testing Workflow
+
+```mermaid
+sequenceDiagram
+    participant Test
+    participant MicroService
+    participant TestServer
+    participant Endpoint
+
+    Test->>MicroService: new MicroService(name)
+    Test->>MicroService: ConfigureApiPipeline()
+    Test->>MicroService: ConfigureTestHost()
+
+    Note over MicroService: Sets ExternalHostFactory
+
+    Test->>MicroService: InitializeAsync(config)
+    MicroService->>TestServer: Create TestServer
+    MicroService-->>Test: Host created
+
+    Test->>MicroService: StartAsync()
+    MicroService->>TestServer: Start
+    TestServer-->>Test: Ready
+
+    Test->>TestServer: GetTestServer()
+    TestServer-->>Test: TestServer instance
+
+    Test->>TestServer: CreateClient()
+    TestServer-->>Test: HttpClient
+
+    Test->>Endpoint: HTTP Request (via HttpClient)
+    Endpoint-->>Test: HTTP Response
+
+    Test->>MicroService: StopAsync()
+    MicroService->>TestServer: Stop
+
+    Test->>MicroService: DisposeAsync()
+    MicroService->>TestServer: Dispose
+```
+
+## ConfigureTestHost Extension
+
+The `ConfigureTestHost()` extension method is the core of the testing framework.
+
+### How It Works
+
+```mermaid
+graph LR
+    ConfigureTestHost[ConfigureTestHost]
+    ExternalHostFactory[ExternalHostFactory]
+    HostBuilder[HostBuilder]
+    TestServer[TestServer]
+    ConfigureWebHost[ConfigureWebHost]
+
+    ConfigureTestHost -->|Sets| ExternalHostFactory
+    ExternalHostFactory -->|Creates| HostBuilder
+    HostBuilder -->|Uses| TestServer
+    HostBuilder -->|Calls| ConfigureWebHost
+    ConfigureWebHost -->|Applies| MicroServiceConfig[MicroService Config]
+
+    style ConfigureTestHost fill:#e1f5ff
+    style ExternalHostFactory fill:#b3e5fc
+    style HostBuilder fill:#81d4fa
+    style TestServer fill:#4fc3f7
+```
+
+### Key Features
+
+- **Idempotent**: Safe to call multiple times (no side effects)
+- **TestServer Integration**: Uses `Microsoft.AspNetCore.TestHost`
+- **Full Configuration**: Preserves all Hive configuration and extensions
+- **In-Memory**: No actual HTTP server required
+
+## Testing with Configuration
+
+```csharp
+[Fact]
+public async Task GivenConfiguration_WhenAccessingEndpoint_ThenConfigurationIsApplied()
+{
+    // Arrange
+    var config = new ConfigurationBuilder()
+        .AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["AppName"] = "TestApp",
+            ["Database:ConnectionString"] = "Server=test;Database=test"
+        })
+        .Build();
+
+    await using var microservice = new MicroService("test-service")
+        .ConfigureServices((services, cfg) =>
+        {
+            // Configuration available here
+            var appName = cfg["AppName"];
+            services.AddSingleton<IMyService>(new MyService(appName));
+        })
+        .ConfigureApiPipeline(endpoints =>
+        {
+            endpoints.MapGet("/api/config", (IConfiguration configuration) =>
+                Results.Ok(new { appName = configuration["AppName"] }));
+        })
+        .ConfigureTestHost();
+
+    // Act
+    await microservice.InitializeAsync(config);
+    await microservice.StartAsync();
+
+    var server = ((MicroService)microservice).Host.GetTestServer();
+    var client = server.CreateClient();
+    var response = await client.GetAsync("/api/config");
+
+    // Assert
+    response.StatusCode.Should().Be(HttpStatusCode.OK);
+    var content = await response.Content.ReadAsStringAsync();
+    content.Should().Contain("TestApp");
+
+    await microservice.StopAsync();
+}
+```
+
+## Testing Multiple Endpoints
+
+```csharp
+[Fact]
+public async Task GivenMultipleEndpoints_WhenMakingRequests_ThenAllRespond()
+{
+    // Arrange
+    var config = new ConfigurationBuilder().Build();
+
+    await using var microservice = new MicroService("test-service")
+        .ConfigureApiPipeline(endpoints =>
+        {
+            endpoints.MapGet("/api/users", () => Results.Ok(new[] { "Alice", "Bob" }));
+            endpoints.MapGet("/api/products", () => Results.Ok(new[] { "Product1", "Product2" }));
+            endpoints.MapPost("/api/orders", () => Results.Created("/api/orders/1", new { id = 1 }));
+        })
+        .ConfigureTestHost();
+
+    await microservice.InitializeAsync(config);
+    await microservice.StartAsync();
+
+    var server = ((MicroService)microservice).Host.GetTestServer();
+    var client = server.CreateClient();
+
+    // Act & Assert - GET /api/users
+    var usersResponse = await client.GetAsync("/api/users");
+    usersResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+    // Act & Assert - GET /api/products
+    var productsResponse = await client.GetAsync("/api/products");
+    productsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+    // Act & Assert - POST /api/orders
+    var ordersResponse = await client.PostAsync("/api/orders", null);
+    ordersResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+    await microservice.StopAsync();
+}
+```
+
+## Testing with Services
+
+```csharp
+public interface IUserService
+{
+    Task<User[]> GetUsersAsync();
+}
+
+public class UserServiceTests
+{
+    [Fact]
+    public async Task GivenUserService_WhenCallingEndpoint_ThenReturnsUsers()
+    {
+        // Arrange
+        var mockUserService = new Mock<IUserService>();
+        mockUserService
+            .Setup(x => x.GetUsersAsync())
+            .ReturnsAsync(new[] { new User { Id = 1, Name = "Alice" } });
+
+        var config = new ConfigurationBuilder().Build();
+
+        await using var microservice = new MicroService("test-service")
+            .ConfigureServices((services, _) =>
+            {
+                services.AddSingleton(mockUserService.Object);
+            })
+            .ConfigureApiPipeline(endpoints =>
+            {
+                endpoints.MapGet("/api/users", async (IUserService userService) =>
+                {
+                    var users = await userService.GetUsersAsync();
+                    return Results.Ok(users);
+                });
+            })
+            .ConfigureTestHost();
+
+        await microservice.InitializeAsync(config);
+        await microservice.StartAsync();
+
+        // Act
+        var server = ((MicroService)microservice).Host.GetTestServer();
+        var client = server.CreateClient();
+        var response = await client.GetAsync("/api/users");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var content = await response.Content.ReadAsStringAsync();
+        content.Should().Contain("Alice");
+
+        mockUserService.Verify(x => x.GetUsersAsync(), Times.Once);
+
+        await microservice.StopAsync();
+    }
+}
+```
+
+## Testing with Extensions
+
+```csharp
+[Fact]
+public async Task GivenExtension_WhenStarted_ThenExtensionIsActive()
+{
+    // Arrange
+    var config = new ConfigurationBuilder().Build();
+
+    await using var microservice = new MicroService("test-service")
+        .WithOpenTelemetry(
+            logging: builder => { /* test logging config */ },
+            tracing: builder => { /* test tracing config */ }
+        )
+        .ConfigureApiPipeline(endpoints =>
+        {
+            endpoints.MapGet("/", () => "Hello");
+        })
+        .ConfigureTestHost();
+
+    // Act
+    await microservice.InitializeAsync(config);
+    await microservice.StartAsync();
+
+    // Assert
+    microservice.Extensions.Should().Contain(e => e is OpenTelemetryExtension);
+
+    var server = ((MicroService)microservice).Host.GetTestServer();
+    var client = server.CreateClient();
+    var response = await client.GetAsync("/");
+    response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+    await microservice.StopAsync();
+}
+```
+
+## Best Practices
+
+### 1. Use Async Disposal
+
+Always use `await using` to ensure proper cleanup:
+
+```csharp
+await using var microservice = new MicroService("test-service")
+    .ConfigureTestHost();
+// Automatically disposed
+```
+
+### 2. Always Call StopAsync
+
+Before disposal, explicitly stop the service:
+
+```csharp
+await microservice.StartAsync();
+// ... tests ...
+await microservice.StopAsync(); // Clean shutdown
+```
+
+### 3. Use Configuration Builders
+
+Build configuration explicitly for tests:
+
+```csharp
+var config = new ConfigurationBuilder()
+    .AddInMemoryCollection(new Dictionary<string, string?>
+    {
+        ["Setting"] = "Value"
+    })
+    .Build();
+```
+
+### 4. Test Categories
+
+Use Hive's test attributes for categorization:
+
+```csharp
+using Hive.Testing;
+
+[Fact]
+[IntegrationTest] // Category: "IntegrationTests"
+public async Task MyIntegrationTest()
+{
+    // ...
+}
+```
+
+### 5. Idempotency
+
+`ConfigureTestHost()` is idempotent - calling it multiple times has no side effects:
+
+```csharp
+var microservice = new MicroService("test")
+    .ConfigureTestHost()
+    .ConfigureTestHost(); // Safe, no duplicate configuration
+```
+
+## Advanced Scenarios
+
+### Custom HttpClient Configuration
+
+```csharp
+var server = ((MicroService)microservice).Host.GetTestServer();
+var client = server.CreateClient();
+
+// Configure client
+client.BaseAddress = new Uri("https://localhost");
+client.DefaultRequestHeaders.Authorization =
+    new AuthenticationHeaderValue("Bearer", "test-token");
+```
+
+### Testing Error Handling
+
+```csharp
+[Fact]
+public async Task GivenInvalidRequest_WhenCalled_ThenReturns400()
+{
+    await using var microservice = new MicroService("test-service")
+        .ConfigureApiPipeline(endpoints =>
+        {
+            endpoints.MapPost("/api/validate", (MyRequest request) =>
+            {
+                if (string.IsNullOrEmpty(request.Name))
+                    return Results.BadRequest("Name is required");
+                return Results.Ok();
+            });
+        })
+        .ConfigureTestHost();
+
+    await microservice.InitializeAsync(new ConfigurationBuilder().Build());
+    await microservice.StartAsync();
+
+    var server = ((MicroService)microservice).Host.GetTestServer();
+    var client = server.CreateClient();
+
+    var response = await client.PostAsJsonAsync("/api/validate", new { });
+
+    response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+
+    await microservice.StopAsync();
+}
+```
+
+## Comparison with Other Testing Approaches
+
+```mermaid
+graph TB
+    subgraph "Hive.MicroServices.Testing"
+        HiveTest[Test Code]
+        HiveTestServer[TestServer]
+        HiveInMemory[In-Memory]
+
+        HiveTest -->|Uses| HiveTestServer
+        HiveTestServer -->|Runs| HiveInMemory
+    end
+
+    subgraph "WebApplicationFactory"
+        WAFTest[Test Code]
+        WAFFactory[WebApplicationFactory]
+        WAFTestServer[TestServer]
+
+        WAFTest -->|Uses| WAFFactory
+        WAFFactory -->|Creates| WAFTestServer
+    end
+
+    subgraph "Manual HTTP Server"
+        ManualTest[Test Code]
+        ManualServer[Kestrel Server]
+        ManualHttp[HTTP Calls]
+
+        ManualTest -->|Calls| ManualHttp
+        ManualHttp -->|Hits| ManualServer
+    end
+
+    style HiveInMemory fill:#4caf50
+    style WAFTestServer fill:#81d4fa
+    style ManualServer fill:#ff9800
+```
+
+| Approach | Speed | Setup Complexity | Isolation | Hive Integration |
+|----------|-------|------------------|-----------|------------------|
+| **Hive.MicroServices.Testing** | ⚡⚡⚡ Fast | ✅ Simple | ✅ Full | ✅ Native |
+| **WebApplicationFactory** | ⚡⚡ Fast | ⚠️ Moderate | ✅ Full | ⚠️ Manual |
+| **Manual HTTP Server** | ⚡ Slow | ❌ Complex | ❌ Partial | ⚠️ Manual |
+
+## Related Libraries
+
+- **[Hive.MicroServices](../Hive.MicroServices/)**: Core microservices framework
+- **[Hive.Testing](../../../hive.core/src/Hive.Testing/)**: Generic testing utilities
+- **[Microsoft.AspNetCore.TestHost](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Testing/)**: ASP.NET Core test infrastructure
+
+## Package Information
+
+- **Package**: `Hive.MicroServices.Testing`
+- **Target Framework**: .NET 10.0
+- **Repository**: https://github.com/cloud-tek/hive
+
+## Example Test Project
+
+See the complete examples in:
+- [Hive.MicroServices.Tests](../../tests/Hive.MicroServices.Tests/)
+- [MicroServiceTests.WebApplicationFactory.cs](../../tests/Hive.MicroServices.Tests/MicroServiceTests.WebApplicationFactory.cs)

--- a/hive.microservices/src/Hive.MicroServices/Lifecycle/StartupService.cs
+++ b/hive.microservices/src/Hive.MicroServices/Lifecycle/StartupService.cs
@@ -13,6 +13,7 @@ public class StartupService : IHostedService
   private readonly IHostApplicationLifetime lifetime;
   private readonly ILogger<StartupService> logger;
   private readonly IMicroService service;
+  private readonly IServiceProvider serviceProvider;
 
   /// <summary>
   /// Initializes a new instance of the <see cref="StartupService"/> class.
@@ -20,11 +21,13 @@ public class StartupService : IHostedService
   /// <param name="service"></param>
   /// <param name="lifetime"></param>
   /// <param name="logger"></param>
-  public StartupService(IMicroService service, IHostApplicationLifetime lifetime, ILogger<StartupService> logger)
+  /// <param name="serviceProvider"></param>
+  public StartupService(IMicroService service, IHostApplicationLifetime lifetime, ILogger<StartupService> logger, IServiceProvider serviceProvider)
   {
     this.service = service ?? throw new ArgumentNullException(nameof(service));
     this.lifetime = lifetime ?? throw new ArgumentNullException(nameof(lifetime));
     this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    this.serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
   }
 
   /// <summary>
@@ -69,7 +72,7 @@ public class StartupService : IHostedService
   private async Task ExecuteHostedStartupServices()
   {
     var svc = (MicroService)service;
-    var svcs = svc.Host.Services.GetServices<IHostedStartupService>();
+    var svcs = serviceProvider.GetServices<IHostedStartupService>();
 
     try
     {

--- a/hive.microservices/src/Hive.MicroServices/Lifecycle/StartupService.cs
+++ b/hive.microservices/src/Hive.MicroServices/Lifecycle/StartupService.cs
@@ -72,6 +72,10 @@ public class StartupService : IHostedService
   private async Task ExecuteHostedStartupServices()
   {
     var svc = (MicroService)service;
+
+    // Use injected IServiceProvider instead of accessing svc.Host.Services
+    // to avoid async-over-sync pattern where Host.Services property access
+    // might block during startup initialization
     var svcs = serviceProvider.GetServices<IHostedStartupService>();
 
     try

--- a/hive.microservices/src/Hive.MicroServices/MicroServiceLifetime.cs
+++ b/hive.microservices/src/Hive.MicroServices/MicroServiceLifetime.cs
@@ -3,8 +3,23 @@ namespace Hive.MicroServices;
 
 internal class MicroServiceLifetime : IMicroServiceLifetime
 {
+  private bool _disposed;
+
   public CancellationToken ServiceStarted => ServiceStartedTokenSource.Token;
   public CancellationTokenSource ServiceStartedTokenSource { get; } = new CancellationTokenSource();
   public CancellationToken StartupFailed => StartupFailedTokenSource.Token;
   internal CancellationTokenSource StartupFailedTokenSource { get; } = new CancellationTokenSource();
+
+  public void Dispose()
+  {
+    if (_disposed)
+    {
+      return;
+    }
+
+    ServiceStartedTokenSource?.Dispose();
+    StartupFailedTokenSource?.Dispose();
+
+    _disposed = true;
+  }
 }

--- a/hive.microservices/src/Hive.MicroServices/MicroServices/IMicroServiceExtensions.cs
+++ b/hive.microservices/src/Hive.MicroServices/MicroServices/IMicroServiceExtensions.cs
@@ -73,26 +73,6 @@ public static class IMicroServiceExtensions
   }
 
   /// <summary>
-  /// Provides an external host factory to the microservice.
-  /// The factory will be called during InitializeAsync with the provided configuration to build the host.
-  /// Use this for integration testing scenarios where the host needs to be built with test-specific configuration.
-  /// </summary>
-  /// <param name="microservice">The microservice instance</param>
-  /// <param name="hostFactory">Factory function that takes configuration and returns a built IHost</param>
-  /// <returns><see cref="IMicroService"/></returns>
-  /// <exception cref="ArgumentNullException">Thrown when any of the provided arguments are null</exception>
-  public static IMicroService WithExternalHostFactory(this IMicroService microservice, Func<IConfigurationRoot, IHost> hostFactory)
-  {
-    _ = microservice ?? throw new ArgumentNullException(nameof(microservice));
-    _ = hostFactory ?? throw new ArgumentNullException(nameof(hostFactory));
-
-    var service = (MicroService)microservice;
-    service.ExternalHostFactory = hostFactory;
-
-    return microservice;
-  }
-
-  /// <summary>
   /// Configures an IWebHostBuilder with the microservice's service registrations and pipeline configuration.
   /// Use this with TestServer for integration testing while keeping all Hive configuration.
   /// </summary>

--- a/hive.microservices/src/Hive.MicroServices/MicroServices/IMicroServiceExtensions.cs
+++ b/hive.microservices/src/Hive.MicroServices/MicroServices/IMicroServiceExtensions.cs
@@ -73,26 +73,6 @@ public static class IMicroServiceExtensions
   }
 
   /// <summary>
-  /// Provides an externally built IHost to the microservice.
-  /// Use this for integration testing with WebApplicationFactory or other test infrastructure.
-  /// When set, InitializeAsync will use the provided host instead of creating a new one.
-  /// </summary>
-  /// <param name="microservice">The microservice instance</param>
-  /// <param name="externalHost">The externally built IHost</param>
-  /// <returns><see cref="IMicroService"/></returns>
-  /// <exception cref="ArgumentNullException">Thrown when any of the provided arguments are null</exception>
-  public static IMicroService WithExternalHost(this IMicroService microservice, IHost externalHost)
-  {
-    _ = microservice ?? throw new ArgumentNullException(nameof(microservice));
-    _ = externalHost ?? throw new ArgumentNullException(nameof(externalHost));
-
-    var service = (MicroService)microservice;
-    service.ExternalHost = externalHost;
-
-    return microservice;
-  }
-
-  /// <summary>
   /// Provides an external host factory to the microservice.
   /// The factory will be called during InitializeAsync with the provided configuration to build the host.
   /// Use this for integration testing scenarios where the host needs to be built with test-specific configuration.

--- a/hive.microservices/src/Hive.MicroServices/Properties/AssemblyInfo.cs
+++ b/hive.microservices/src/Hive.MicroServices/Properties/AssemblyInfo.cs
@@ -5,3 +5,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Hive.MicroServices.Grpc")]
 [assembly: InternalsVisibleTo("Hive.MicroServices.GraphQL")]
 [assembly: InternalsVisibleTo("Hive.MicroServices.Job")]
+[assembly: InternalsVisibleTo("Hive.MicroServices.Tests")]

--- a/hive.microservices/src/Hive.MicroServices/Properties/AssemblyInfo.cs
+++ b/hive.microservices/src/Hive.MicroServices/Properties/AssemblyInfo.cs
@@ -5,4 +5,5 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Hive.MicroServices.Grpc")]
 [assembly: InternalsVisibleTo("Hive.MicroServices.GraphQL")]
 [assembly: InternalsVisibleTo("Hive.MicroServices.Job")]
+[assembly: InternalsVisibleTo("Hive.MicroServices.Testing")]
 [assembly: InternalsVisibleTo("Hive.MicroServices.Tests")]

--- a/hive.microservices/src/Hive.MicroServices/README.md
+++ b/hive.microservices/src/Hive.MicroServices/README.md
@@ -1,0 +1,386 @@
+# Hive.MicroServices
+
+Core microservices framework for building ASP.NET Core applications with the Hive platform.
+
+## Overview
+
+`Hive.MicroServices` provides an opinionated, extensible framework for building microservices on ASP.NET Core. It follows a plugin-based architecture where all features are implemented as extensions to the core `IMicroService` abstraction.
+
+## Architecture
+
+### Core Components
+
+```mermaid
+graph TB
+    IMicroService[IMicroService Interface]
+    MicroService[MicroService Implementation]
+    Extensions[MicroServiceExtension]
+    IHost[ASP.NET Core IHost]
+
+    IMicroService -->|Implemented by| MicroService
+    MicroService -->|Creates| IHost
+    MicroService -->|Hosts| Extensions
+    Extensions -->|Configure| IHost
+
+    style IMicroService fill:#e1f5ff
+    style MicroService fill:#b3e5fc
+    style Extensions fill:#81d4fa
+    style IHost fill:#4fc3f7
+```
+
+### Key Interfaces
+
+- **`IMicroService`**: Core abstraction representing a microservice instance
+- **`MicroServiceExtension`**: Base class for all framework extensions
+- **`IMicroServiceLifetime`**: Lifecycle event management (startup, failure)
+
+## Lifecycle
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant MicroService
+    participant Extensions
+    participant IHost
+    participant Lifetime
+
+    User->>MicroService: new MicroService(name)
+    User->>MicroService: RegisterExtension<T>()
+    User->>MicroService: Configure*()
+
+    User->>MicroService: InitializeAsync(config)
+    MicroService->>Extensions: ConfigureServices()
+    MicroService->>IHost: Create Host
+    MicroService->>MicroService: ConfigurationRoot = config
+
+    User->>MicroService: StartAsync()
+    MicroService->>MicroService: Validate PipelineMode
+    MicroService->>IHost: StartAsync()
+    IHost-->>Lifetime: Signal ServiceStarted
+
+    Note over MicroService,IHost: Service Running
+
+    User->>MicroService: StopAsync()
+    MicroService->>IHost: StopAsync()
+
+    User->>MicroService: DisposeAsync()
+    MicroService->>IHost: Dispose()
+    MicroService->>Lifetime: Dispose()
+```
+
+## Pipeline Modes
+
+The framework supports multiple service types through pipeline modes:
+
+| Mode | Description | Use Case |
+|------|-------------|----------|
+| `Api` | Minimal APIs with endpoint routing | Modern REST APIs |
+| `ApiControllers` | Traditional controller-based APIs | Legacy-compatible APIs |
+| `GraphQL` | GraphQL APIs via HotChocolate | GraphQL services |
+| `Grpc` | gRPC services (protobuf-first) | High-performance RPC |
+| `Job` | Background worker services | Scheduled tasks, workers |
+| `None` | Basic service without HTTP | Console apps, utilities |
+
+## Basic Usage
+
+### Creating a Microservice
+
+```csharp
+using Hive;
+using Hive.MicroServices.Api;
+
+var microservice = new MicroService("my-service")
+    .ConfigureApiPipeline(endpoints =>
+    {
+        endpoints.MapGet("/health", () => Results.Ok("Healthy"));
+        endpoints.MapGet("/api/users", () => Results.Ok(new[] { "Alice", "Bob" }));
+    });
+
+await microservice.RunAsync();
+```
+
+### With Configuration
+
+```csharp
+var config = new ConfigurationBuilder()
+    .AddJsonFile("appsettings.json")
+    .AddEnvironmentVariables()
+    .Build();
+
+var microservice = new MicroService("my-service")
+    .ConfigureServices((services, configuration) =>
+    {
+        services.AddSingleton<IMyService, MyService>();
+    })
+    .ConfigureApiPipeline(endpoints =>
+    {
+        endpoints.MapGet("/api/data", (IMyService service) =>
+            Results.Ok(service.GetData()));
+    });
+
+await microservice.RunAsync(config);
+```
+
+### With Extensions
+
+```csharp
+var microservice = new MicroService("my-service")
+    .WithOpenTelemetry(
+        logging: builder => { /* configure logging */ },
+        tracing: builder => { /* configure tracing */ }
+    )
+    .RegisterExtension<MyCustomExtension>()
+    .ConfigureApiPipeline(endpoints =>
+    {
+        endpoints.MapGet("/", () => "Hello World");
+    });
+
+await microservice.RunAsync();
+```
+
+## Extension Pattern
+
+All framework features are implemented as extensions inheriting from `MicroServiceExtension`.
+
+```mermaid
+graph LR
+    MicroServiceExtension[MicroServiceExtension]
+    OpenTelemetry[OpenTelemetry Extension]
+    Api[API Extension]
+    GraphQL[GraphQL Extension]
+    Grpc[gRPC Extension]
+    Custom[Custom Extension]
+
+    MicroServiceExtension --> OpenTelemetry
+    MicroServiceExtension --> Api
+    MicroServiceExtension --> GraphQL
+    MicroServiceExtension --> Grpc
+    MicroServiceExtension --> Custom
+
+    style MicroServiceExtension fill:#e1f5ff
+    style OpenTelemetry fill:#81d4fa
+    style Api fill:#81d4fa
+    style GraphQL fill:#81d4fa
+    style Grpc fill:#81d4fa
+    style Custom fill:#4fc3f7
+```
+
+### Creating a Custom Extension
+
+```csharp
+public class MyCustomExtension : MicroServiceExtension
+{
+    public MyCustomExtension(IMicroService microService) : base(microService)
+    {
+    }
+
+    public override void ConfigureServices(IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddSingleton<IMyCustomService, MyCustomService>();
+    }
+
+    public override void Configure(IApplicationBuilder app)
+    {
+        app.UseMiddleware<MyCustomMiddleware>();
+    }
+}
+```
+
+## Configuration Patterns
+
+The framework provides two-phase configuration for different scenarios:
+
+### Pre-configuration
+
+Use when configuration is needed **before** `IServiceProvider` is built:
+
+```csharp
+services.PreConfigureValidatedOptions<MyOptions>(
+    configuration.GetSection("MySection")
+);
+```
+
+### Post-configuration
+
+Standard options pattern **after** service provider is available:
+
+```csharp
+services.ConfigureValidatedOptions<MyOptions>(
+    configuration.GetSection("MySection")
+);
+```
+
+Both support validation via:
+- DataAnnotations
+- FluentValidation
+- Custom delegates
+
+## Kubernetes Integration
+
+Built-in middleware provides probe endpoints for Kubernetes:
+
+```mermaid
+graph LR
+    K8s[Kubernetes]
+    Startup[/startup Probe]
+    Readiness[/readiness Probe]
+    Liveness[/liveness Probe]
+    MicroService[MicroService]
+
+    K8s -->|Checks| Startup
+    K8s -->|Checks| Readiness
+    K8s -->|Checks| Liveness
+
+    Startup -->|IsStarted| MicroService
+    Readiness -->|IsReady| MicroService
+    Liveness -->|IsAlive| MicroService
+
+    style K8s fill:#326ce5
+    style Startup fill:#81d4fa
+    style Readiness fill:#81d4fa
+    style Liveness fill:#81d4fa
+    style MicroService fill:#b3e5fc
+```
+
+### Probe Endpoints
+
+- **`/startup`**: Returns 200 when `IMicroService.IsStarted == true`
+- **`/readiness`**: Returns 200 when `IMicroService.IsReady == true`
+- **`/liveness`**: Returns 200 when service is alive
+
+## Initialization Modes
+
+### RunAsync (Blocking)
+
+Initializes, starts, and blocks until the service stops:
+
+```csharp
+var exitCode = await microservice.RunAsync(config);
+// Execution blocks here until service stops
+return exitCode;
+```
+
+### InitializeAsync + StartAsync (Non-blocking)
+
+For scenarios requiring manual control:
+
+```csharp
+await microservice.InitializeAsync(config);
+await microservice.StartAsync();
+
+// Service is running, execution continues
+// Do other work...
+
+await microservice.StopAsync();
+```
+
+## Disposal
+
+The framework implements proper disposal patterns for resource management:
+
+```csharp
+// Async disposal (preferred)
+await using var microservice = new MicroService("my-service")
+    .ConfigureApiPipeline(/* ... */);
+
+await microservice.InitializeAsync(config);
+await microservice.StartAsync();
+// Automatically disposed at end of scope
+
+// Synchronous disposal (fallback)
+using var microservice = new MicroService("my-service");
+// ...
+```
+
+### What Gets Disposed
+
+```mermaid
+graph TD
+    MicroService[MicroService.DisposeAsync]
+    Host[IHost.Dispose]
+    CTS[CancellationTokenSource.Dispose]
+    Lifetime[IMicroServiceLifetime.Dispose]
+    ServiceStarted[ServiceStartedTokenSource.Dispose]
+    StartupFailed[StartupFailedTokenSource.Dispose]
+
+    MicroService --> Host
+    MicroService --> CTS
+    MicroService --> Lifetime
+    Lifetime --> ServiceStarted
+    Lifetime --> StartupFailed
+
+    style MicroService fill:#e1f5ff
+    style Host fill:#81d4fa
+    style CTS fill:#81d4fa
+    style Lifetime fill:#81d4fa
+```
+
+## Error Handling
+
+```csharp
+try
+{
+    await microservice.StartAsync();
+}
+catch (ConfigurationException ex)
+{
+    // Pipeline mode not set or validation failed
+    logger.LogError(ex, "Configuration error");
+    throw;
+}
+catch (Exception ex)
+{
+    // Startup failed
+    logger.LogError(ex, "Startup failed");
+    throw;
+}
+```
+
+### Startup Failure Detection
+
+```csharp
+// Using lifetime events
+microservice.Lifetime.StartupFailed.Register(() =>
+{
+    logger.LogError("Service failed to start");
+});
+
+await microservice.StartAsync();
+```
+
+## Advanced Scenarios
+
+### Custom Assembly Provider
+
+For testing scenarios where entry assembly needs to be controlled:
+
+```csharp
+var microservice = new MicroService("test-service");
+((MicroService)microservice).MicroServiceEntrypointAssemblyProvider =
+    () => typeof(MyTestClass).Assembly;
+```
+
+### Accessing Service Provider
+
+```csharp
+await microservice.InitializeAsync(config);
+
+// Access services after initialization
+var myService = microservice.ServiceProvider.GetRequiredService<IMyService>();
+```
+
+## Related Libraries
+
+- **[Hive.Abstractions](../../hive.core/src/Hive.Abstractions/)**: Core abstractions and interfaces
+- **[Hive.MicroServices.Api](../Hive.MicroServices.Api/)**: REST API extensions (Minimal APIs, Controllers)
+- **[Hive.MicroServices.GraphQL](../Hive.MicroServices.GraphQL/)**: GraphQL support
+- **[Hive.MicroServices.Grpc](../Hive.MicroServices.Grpc/)**: gRPC support
+- **[Hive.MicroServices.Job](../Hive.MicroServices.Job/)**: Background job support
+- **[Hive.MicroServices.Testing](../Hive.MicroServices.Testing/)**: Testing utilities
+- **[Hive.OpenTelemetry](../../hive.opentelemetry/)**: OpenTelemetry integration
+
+## Package Information
+
+- **Package**: `Hive.MicroServices`
+- **Target Framework**: .NET 10.0
+- **Repository**: https://github.com/cloud-tek/hive

--- a/hive.microservices/tests/Hive.MicroServices.Tests/Hive.MicroServices.Tests.csproj
+++ b/hive.microservices/tests/Hive.MicroServices.Tests/Hive.MicroServices.Tests.csproj
@@ -8,6 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/hive.microservices/tests/Hive.MicroServices.Tests/Hive.MicroServices.Tests.csproj
+++ b/hive.microservices/tests/Hive.MicroServices.Tests/Hive.MicroServices.Tests.csproj
@@ -29,6 +29,7 @@
     <ProjectReference Include="..\..\src\Hive.MicroServices.GraphQL\Hive.MicroServices.GraphQL.csproj" />
     <ProjectReference Include="..\..\src\Hive.MicroServices.Grpc\Hive.MicroServices.Grpc.csproj" />
     <ProjectReference Include="..\..\src\Hive.MicroServices.Job\Hive.MicroServices.Job.csproj" />
+    <ProjectReference Include="..\..\src\Hive.MicroServices.Testing\Hive.MicroServices.Testing.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/hive.microservices/tests/Hive.MicroServices.Tests/MicroServiceTests.Startup.cs
+++ b/hive.microservices/tests/Hive.MicroServices.Tests/MicroServiceTests.Startup.cs
@@ -43,6 +43,7 @@ public partial class MicroServiceTests
     public async Task GivenRunAsyncIsInvoked_WhenNoIHostedStartupServicesAreUsed_ThenServiceShouldStartImmediately()
     {
       // Arrange
+      using var portScope = TestPortProvider.GetAvailableServicePortScope(5000, out var port);
       var config = new ConfigurationBuilder().Build();
 
       var service = new MicroService(ServiceName, new NullLogger<IMicroService>())
@@ -64,6 +65,7 @@ public partial class MicroServiceTests
     public async Task GivenRunAsyncIsInvoked_WhenNonFailingIHostedStartupServicesAreUsed_ThenServiceShouldStart()
     {
       // Arrange
+      using var portScope = TestPortProvider.GetAvailableServicePortScope(5000, out var port);
       var config = new ConfigurationBuilder().Build();
 
       var service = new MicroService(ServiceName, new NullLogger<IMicroService>())
@@ -90,6 +92,7 @@ public partial class MicroServiceTests
     public async Task GivenRunAsyncIsInvoked_WhenFailingIHostedStartupServicesAreUsed_ThenServiceShouldFailToStart()
     {
       // Arrange
+      using var portScope = TestPortProvider.GetAvailableServicePortScope(5000, out var port);
       var config = new ConfigurationBuilder().Build();
 
       var service = new MicroService(ServiceName, new NullLogger<IMicroService>())

--- a/hive.microservices/tests/Hive.MicroServices.Tests/MicroServiceTests.WebApplicationFactory.cs
+++ b/hive.microservices/tests/Hive.MicroServices.Tests/MicroServiceTests.WebApplicationFactory.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Hive.MicroServices.Api;
+using Hive.MicroServices.Testing;
 using Hive.Testing;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/hive.microservices/tests/Hive.MicroServices.Tests/MicroServiceTests.WebApplicationFactory.cs
+++ b/hive.microservices/tests/Hive.MicroServices.Tests/MicroServiceTests.WebApplicationFactory.cs
@@ -29,12 +29,12 @@ public partial class MicroServiceTests
       // Arrange
       var config = new ConfigurationBuilder().Build();
 
-      var microservice = new MicroService(ServiceName, new NullLogger<IMicroService>())
+      await using var microservice = new MicroService(ServiceName, new NullLogger<IMicroService>())
         .ConfigureApiPipeline(endpoints =>
         {
           endpoints.MapGet("/api/test", () => Results.Ok(new { message = "Hello from Hive" }));
         })
-        .UseTestHost();
+        .ConfigureTestHost();
 
       // Act - Initialize and start using IMicroService APIs
       await microservice.InitializeAsync(config);
@@ -60,14 +60,14 @@ public partial class MicroServiceTests
       // Arrange
       var config = new ConfigurationBuilder().Build();
 
-      var microservice = new MicroService(ServiceName, new NullLogger<IMicroService>())
+      await using var microservice = new MicroService(ServiceName, new NullLogger<IMicroService>())
         .ConfigureApiPipeline(endpoints =>
         {
           endpoints.MapGet("/api/users", () => Results.Ok(new[] { "Alice", "Bob" }));
           endpoints.MapGet("/api/products", () => Results.Ok(new[] { "Product1", "Product2" }));
           endpoints.MapPost("/api/orders", () => Results.Created("/api/orders/1", new { id = 1, status = "created" }));
         })
-        .UseTestHost();
+        .ConfigureTestHost();
 
       // Act - Initialize and start using IMicroService APIs
       await microservice.InitializeAsync(config);
@@ -110,7 +110,7 @@ public partial class MicroServiceTests
         })
         .Build();
 
-      var microservice = new MicroService(ServiceName, new NullLogger<IMicroService>())
+      await using var microservice = new MicroService(ServiceName, new NullLogger<IMicroService>())
         .ConfigureServices((services, cfg) =>
         {
           // Configuration is available here via cfg parameter
@@ -120,7 +120,7 @@ public partial class MicroServiceTests
           endpoints.MapGet("/api/config", (IConfiguration configuration) =>
             Results.Ok(new { appName = configuration["AppName"] }));
         })
-        .UseTestHost();
+        .ConfigureTestHost();
 
       // Act - Initialize and start using IMicroService APIs
       await microservice.InitializeAsync(config);

--- a/hive.microservices/tests/Hive.MicroServices.Tests/MicroServiceTests.WebApplicationFactory.cs
+++ b/hive.microservices/tests/Hive.MicroServices.Tests/MicroServiceTests.WebApplicationFactory.cs
@@ -1,0 +1,142 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Hive.MicroServices.Api;
+using Hive.Testing;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Hive.MicroServices.Tests;
+
+public partial class MicroServiceTests
+{
+  public class WebHostIntegration
+  {
+    private const string ServiceName = "microservice-webhost-tests";
+
+    [Fact]
+    [IntegrationTest]
+    public async Task GivenMicroServiceWithConfigureWebHost_WhenCreatingTestServer_ThenServerUsesHiveConfiguration()
+    {
+      // Arrange
+      var config = new ConfigurationBuilder().Build();
+
+      var microservice = new MicroService(ServiceName, new NullLogger<IMicroService>())
+        .ConfigureApiPipeline(endpoints =>
+        {
+          endpoints.MapGet("/api/test", () => Results.Ok(new { message = "Hello from Hive" }));
+        })
+        .UseTestHost();
+
+      // Act - Initialize and start using IMicroService APIs
+      await microservice.InitializeAsync(config);
+      await microservice.StartAsync();
+
+      var server = ((MicroService)microservice).Host.GetTestServer();
+      var client = server.CreateClient();
+      var response = await client.GetAsync("/api/test");
+
+      // Assert
+      response.StatusCode.Should().Be(HttpStatusCode.OK);
+      var content = await response.Content.ReadAsStringAsync();
+      content.Should().Contain("Hello from Hive");
+
+      // Cleanup
+      await microservice.StopAsync();
+    }
+
+    [Fact]
+    [IntegrationTest]
+    public async Task GivenMicroServiceWithMultipleEndpoints_WhenMakingRequests_ThenAllEndpointsRespond()
+    {
+      // Arrange
+      var config = new ConfigurationBuilder().Build();
+
+      var microservice = new MicroService(ServiceName, new NullLogger<IMicroService>())
+        .ConfigureApiPipeline(endpoints =>
+        {
+          endpoints.MapGet("/api/users", () => Results.Ok(new[] { "Alice", "Bob" }));
+          endpoints.MapGet("/api/products", () => Results.Ok(new[] { "Product1", "Product2" }));
+          endpoints.MapPost("/api/orders", () => Results.Created("/api/orders/1", new { id = 1, status = "created" }));
+        })
+        .UseTestHost();
+
+      // Act - Initialize and start using IMicroService APIs
+      await microservice.InitializeAsync(config);
+      await microservice.StartAsync();
+
+      var server = ((MicroService)microservice).Host.GetTestServer();
+      var client = server.CreateClient();
+
+      // Act & Assert - GET /api/users
+      var usersResponse = await client.GetAsync("/api/users");
+      usersResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+      var usersContent = await usersResponse.Content.ReadAsStringAsync();
+      usersContent.Should().Contain("Alice");
+
+      // Act & Assert - GET /api/products
+      var productsResponse = await client.GetAsync("/api/products");
+      productsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+      var productsContent = await productsResponse.Content.ReadAsStringAsync();
+      productsContent.Should().Contain("Product1");
+
+      // Act & Assert - POST /api/orders
+      var ordersResponse = await client.PostAsync("/api/orders", null);
+      ordersResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+      var ordersContent = await ordersResponse.Content.ReadAsStringAsync();
+      ordersContent.Should().Contain("created");
+
+      // Cleanup
+      await microservice.StopAsync();
+    }
+
+    [Fact]
+    [IntegrationTest]
+    public async Task GivenMicroServiceWithCustomConfiguration_WhenAccessingEndpoints_ThenConfigurationIsApplied()
+    {
+      // Arrange
+      var config = new ConfigurationBuilder()
+        .AddInMemoryCollection(new Dictionary<string, string?>
+        {
+          ["AppName"] = "TestApp"
+        })
+        .Build();
+
+      var microservice = new MicroService(ServiceName, new NullLogger<IMicroService>())
+        .ConfigureServices((services, cfg) =>
+        {
+          // Configuration is available here via cfg parameter
+        })
+        .ConfigureApiPipeline(endpoints =>
+        {
+          endpoints.MapGet("/api/config", (IConfiguration configuration) =>
+            Results.Ok(new { appName = configuration["AppName"] }));
+        })
+        .UseTestHost();
+
+      // Act - Initialize and start using IMicroService APIs
+      await microservice.InitializeAsync(config);
+      await microservice.StartAsync();
+
+      var server = ((MicroService)microservice).Host.GetTestServer();
+      var client = server.CreateClient();
+      var response = await client.GetAsync("/api/config");
+
+      // Assert
+      response.StatusCode.Should().Be(HttpStatusCode.OK);
+      var content = await response.Content.ReadAsStringAsync();
+      content.Should().Contain("TestApp");
+
+      // Cleanup
+      await microservice.StopAsync();
+    }
+  }
+}

--- a/hive.microservices/tests/Hive.MicroServices.Tests/TestingExtensions/IMicroServiceTestingExtensions.cs
+++ b/hive.microservices/tests/Hive.MicroServices.Tests/TestingExtensions/IMicroServiceTestingExtensions.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace Hive.MicroServices;
+
+/// <summary>
+/// Testing extension methods for <see cref="IMicroService"/>
+/// </summary>
+public static class IMicroServiceTestingExtensions
+{
+  /// <summary>
+  /// Prepares the microservice to use a TestServer-based external host.
+  /// The host will be created during InitializeAsync with the configuration provided there.
+  /// After calling this method, use microservice.InitializeAsync(config) to build and initialize the host,
+  /// then microservice.StartAsync() to start it.
+  /// </summary>
+  /// <param name="microservice">The microservice instance</param>
+  /// <returns>The microservice instance for fluent chaining</returns>
+  /// <exception cref="ArgumentNullException">Thrown when microservice is null</exception>
+  public static IMicroService UseTestHost(this IMicroService microservice)
+  {
+    _ = microservice ?? throw new ArgumentNullException(nameof(microservice));
+
+    // Set a factory that will be called during InitializeAsync with the configuration
+    return microservice.WithExternalHostFactory(config =>
+    {
+      var hostBuilder = new HostBuilder()
+        .ConfigureWebHost(webHostBuilder =>
+        {
+          webHostBuilder.UseTestServer();
+          microservice.ConfigureWebHost(webHostBuilder, config);
+        });
+
+      return hostBuilder.Build();
+    });
+  }
+}

--- a/hive.opentelemetry/tests/Hive.OpenTelemetry.Tests/E2E/LogEmissionTests.cs
+++ b/hive.opentelemetry/tests/Hive.OpenTelemetry.Tests/E2E/LogEmissionTests.cs
@@ -190,7 +190,7 @@ public class LogEmissionTests : E2ETestBase
       ServiceName,
       app => app.MapGet("/multiple-test", (ILogger<LogEmissionTests> logger) =>
       {
-        for (int i = 1; i <= 5; i++)
+        for (var i = 1; i <= 5; i++)
         {
           logger.LogInformation("Log message number {Number}", i);
         }

--- a/hive.opentelemetry/tests/Hive.OpenTelemetry.Tests/E2E/MetricsEmissionTests.cs
+++ b/hive.opentelemetry/tests/Hive.OpenTelemetry.Tests/E2E/MetricsEmissionTests.cs
@@ -54,7 +54,7 @@ public class MetricsEmissionTests : E2ETestBase
       using var client = CreateHttpClient();
 
       // Make multiple requests
-      for (int i = 0; i < 5; i++)
+      for (var i = 0; i < 5; i++)
       {
         await client.GetAsync("/accumulate-test");
       }


### PR DESCRIPTION
This commit introduces comprehensive integration testing capabilities:

- Add InitializeAsync, StartAsync, and StopAsync methods to IMicroService for granular lifecycle control
- Add WithExternalHost and WithExternalHostFactory extensions for test infrastructure integration
- Add ConfigureWebHost extension for seamless WebApplicationFactory integration
- Fix StartupService to prevent async-over-sync anti-pattern by accepting IServiceProvider
- Add Microsoft.AspNetCore.Mvc.Testing and TestHost packages for testing infrastructure
- Add WebApplicationFactory-based test helpers and MicroServiceTestingExtensions
- Add TestPortProvider usage to startup tests to prevent port conflicts
- Refactor loop variables to use 'var' for consistency

The new testing APIs enable:
- External control of microservice lifecycle (initialize, start, stop separately)
- Integration with ASP.NET Core's WebApplicationFactory
- TestServer-based testing while preserving all Hive configuration
- Improved test isolation and reliability

🤖 Generated with [Claude Code](https://claude.com/claude-code)