### PR TITLE
fix: invoke extension ConfigureActions during FunctionHost build (#58)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,7 +11,7 @@ permissions:
   id-token: write
 jobs:
   review:
-    uses: cloud-tek/poc-claude-review/.github/workflows/claude-code-review.yml@v0.0.1
+    uses: cloud-tek-poc/poc-claude-review/.github/workflows/claude-code-review.yml@v0.0.1
     with:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.event.pull_request.base.ref }}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,35 +6,35 @@
   <ItemGroup>
     <PackageVersion Include="FluentAssertions" Version="[7.2.0]" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
-    <PackageVersion Include="Grpc.AspNetCore" Version="2.76.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
+    <PackageVersion Include="Grpc.AspNetCore" Version="2.80.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageVersion Include="protobuf-net.Grpc.AspNetCore" Version="1.2.2" />
-    <PackageVersion Include="HotChocolate.AspNetCore" Version="15.1.15" />
+    <PackageVersion Include="HotChocolate.AspNetCore" Version="16.0.3" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
-    <PackageVersion Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.5.0" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
     <PackageVersion Include="Refit" Version="10.1.6" />
     <PackageVersion Include="Refit.HttpClientFactory" Version="10.1.6" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="MiniValidation" Version="0.9.2" />
     <PackageVersion Include="Scrutor" Version="7.0.0" />

--- a/hive.functions/src/Hive.Functions/FunctionHost.cs
+++ b/hive.functions/src/Hive.Functions/FunctionHost.cs
@@ -186,6 +186,18 @@ public class FunctionHost : IFunctionHost
       {
         action(services, context.Configuration);
       }
+
+      // Apply deferred service configuration actions queued by each registered extension.
+      // Mirrors Hive.MicroServices.MicroService — extensions populate ConfigureActions
+      // from their constructors (e.g. Hive.OpenTelemetry.Extension); the host contract
+      // is to invoke them during DI build.
+      foreach (var extension in Extensions)
+      {
+        foreach (var action in extension.ConfigureActions)
+        {
+          action(services, context.Configuration);
+        }
+      }
     });
 
     return builder.Build();

--- a/hive.functions/tests/Hive.Functions.Tests/FunctionHostTests.cs
+++ b/hive.functions/tests/Hive.Functions.Tests/FunctionHostTests.cs
@@ -1,6 +1,10 @@
+using System.Reflection;
 using CloudTek.Testing;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
 using Xunit;
 
 namespace Hive.Functions.Tests;
@@ -172,6 +176,57 @@ public class FunctionHostTests
     act.Should().NotThrow<NullReferenceException>();
   }
 
+  [Fact]
+  [IntegrationTest]
+  public async Task Issue58_WithOpenTelemetry_OnFunctionHost_ShouldRegisterOpenTelemetryProviders()
+  {
+    // Issue #58 repro, lifted from the bug report:
+    //
+    //   var host = new FunctionHost("demo-functions")
+    //       .WithOpenTelemetry(additionalActivitySources: new[] { "My.App.ActivitySource" });
+    //   await host.RunAsync();
+    //
+    // RunAsync would launch the Functions worker; InitializeAsync drives the same
+    // CreateHostBuilder path, materialising the IServiceProvider without starting it.
+    var functionHost = new FunctionHost("demo-functions")
+      .WithOpenTelemetry(additionalActivitySources: new[] { "My.App.ActivitySource" });
+
+    var core = (IMicroServiceCore)functionHost;
+    await core.InitializeAsync();
+
+    var hostField = typeof(FunctionHost).GetField("host", BindingFlags.NonPublic | BindingFlags.Instance);
+    var iHost = (IHost?)hostField!.GetValue(functionHost);
+    iHost.Should().NotBeNull("InitializeAsync must build the underlying IHost");
+
+    iHost!.Services.GetService<TracerProvider>().Should().NotBeNull(
+      "WithOpenTelemetry must register a TracerProvider on the function host (issue #58)");
+    iHost.Services.GetService<MeterProvider>().Should().NotBeNull(
+      "WithOpenTelemetry must register a MeterProvider on the function host (issue #58)");
+
+    await functionHost.DisposeAsync();
+  }
+
+  [Fact]
+  [UnitTest]
+  public async Task FunctionHost_InitializeAsync_ShouldInvokeEachExtensionsConfigureActions()
+  {
+    // Pins the host contract: FunctionHost must walk Extensions[i].ConfigureActions
+    // during DI build, matching Hive.MicroServices.MicroService. See issue #58.
+    var marker = new SentinelMarker();
+    var functionHost = new FunctionHost("test-function");
+    var sentinel = new SentinelExtension(functionHost, marker);
+    functionHost.Extensions.Add(sentinel);
+
+    var core = (IMicroServiceCore)functionHost;
+    await core.InitializeAsync();
+
+    marker.CallbackInvoked.Should().BeTrue(
+      "FunctionHost must iterate Extensions[i].ConfigureActions during build (issue #58)");
+    marker.CapturedServices.Should().NotBeNull();
+
+    await functionHost.DisposeAsync();
+  }
+
   /// <summary>
   /// Test service for DI validation
   /// </summary>
@@ -186,6 +241,25 @@ public class FunctionHostTests
   {
     public TestExtension(IMicroServiceCore service) : base(service)
     {
+    }
+  }
+
+  private sealed class SentinelMarker
+  {
+    public bool CallbackInvoked { get; set; }
+    public IServiceCollection? CapturedServices { get; set; }
+  }
+
+  private sealed class SentinelExtension : MicroServiceExtension<SentinelExtension>
+  {
+    public SentinelExtension(IMicroServiceCore service, SentinelMarker marker)
+      : base(service)
+    {
+      ConfigureActions.Add((services, _) =>
+      {
+        marker.CallbackInvoked = true;
+        marker.CapturedServices = services;
+      });
     }
   }
 }


### PR DESCRIPTION
## Summary
- Fixes #58 — `Hive.Functions.WithOpenTelemetry(...)` was a structural no-op on `FunctionHost`. `CreateHostBuilder` walked the host's own private `configureActions` list but never iterated `Extensions[i].ConfigureActions`, so the OpenTelemetry extension (which queues its real wiring into that list) never built any `TracerProvider` / `MeterProvider` / `LoggerProvider`. Function apps appeared to be OTel-enabled but emitted nothing.
- Fix mirrors the iteration pattern from `Hive.MicroServices.MicroService` so any extension following the `ConfigureActions` convention works on both hosts. Non-breaking — iterating empty lists on extensions that don't use them is a no-op.
- Also bumps packages to unblock `OutdatedCheck` and clear pre-existing `NU1902` OTel vulnerability advisories (OpenTelemetry.* 1.15.3, Microsoft.AspNetCore/Extensions 10.0.8, Grpc.AspNetCore 2.80.0, HotChocolate.AspNetCore 16.0.3).

## Test plan
- [x] `dotnet test hive.functions/tests/Hive.Functions.Tests/Hive.Functions.Tests.csproj` — 13/13 pass with the fix; the new `Issue58_WithOpenTelemetry_OnFunctionHost_ShouldRegisterOpenTelemetryProviders` integration test fails without it (negative-control verified locally — `TracerProvider` resolves to null pre-fix, exactly the bug symptom in DI form)
- [x] `FunctionHost_InitializeAsync_ShouldInvokeEachExtensionsConfigureActions` unit test pins the host contract via a sentinel extension — guards future `ConfigureActions`-style extensions against the same defect
- [x] `dotnet tool run cloudtek-build --target All` — full pipeline green including `OutdatedCheck`, `Compile`, `UnitTests`, `IntegrationTests`, `Pack`, `Publish`
- [ ] Optional manual smoke: run `Hive.Functions.Demo` under an Aspire AppHost with `OTEL_EXPORTER_OTLP_ENDPOINT` set, verify traces/metrics land in the dashboard (this is the original reproduction from #58)

## Follow-ups (deferred to keep this PR focused)
- Delete the now-redundant per-host `Hive.Functions.OpenTelemetryExtensions` shim — the generic `WithOpenTelemetry<THost>` from `Hive.OpenTelemetry` resolves correctly once the host walks `ConfigureActions`.
- Reconsider the manual `extension.ConfigureServices(...)` queuing inside `FunctionHost.RegisterExtension` (now overlaps with the new host-level iteration).
- Document the host contract on `MicroServiceExtension.ConfigureActions`: host implementations MUST iterate this list during service configuration.