### PR TITLE
fix(#66): fail-fast on conflicting environment variables (10.1.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ This repository uses centralized package management (`ManagePackageVersionsCentr
 - All package versions are defined in `Directory.Packages.props`
 - Projects reference packages WITHOUT version numbers
 - `Directory.Build.props` sets global properties (target framework: net10.0)
-- Custom MSBuild SDK: `CloudTek.Sdk` (version 10.0.0-beta.5)
+- Custom MSBuild SDK: `CloudTek.Sdk` (version 10.0.0)
 
 When adding a new package:
 1. Add the `<PackageVersion>` entry to `Directory.Packages.props`

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,8 @@
     <PackageVersion Include="protobuf-net.Grpc.AspNetCore" Version="1.2.2" />
     <PackageVersion Include="HotChocolate.AspNetCore" Version="16.2.*" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
+    <!-- Transitive pin: overrides MessagePack 2.5.192 (Aspire.Hosting → StreamJsonRpc) to clear GHSA-hv8m-jj95-wg3x -->
+    <PackageVersion Include="MessagePack" Version="2.5.302" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />

--- a/global.json
+++ b/global.json
@@ -3,6 +3,6 @@
     "version": "10.0.100"
   },
   "msbuild-sdks": {
-    "CloudTek.Sdk": "10.0.0-beta.5"
+    "CloudTek.Sdk": "10.0.0"
   }
 }

--- a/hive.core/src/Hive.Abstractions/Constants.Environment.cs
+++ b/hive.core/src/Hive.Abstractions/Constants.Environment.cs
@@ -34,6 +34,11 @@ public static partial class Constants
       /// The DOTNET_RUNNING_IN_CONTAINER environment variable
       /// </summary>
       public const string DotNetRunningInContainer = "DOTNET_RUNNING_IN_CONTAINER";
+
+      /// <summary>
+      /// The DOTNET_ENVIRONMENT environment variable
+      /// </summary>
+      public const string RuntimeEnvironment = "DOTNET_ENVIRONMENT";
     }
 
     /// <summary>

--- a/hive.core/src/Hive.Abstractions/Constants.Errors.cs
+++ b/hive.core/src/Hive.Abstractions/Constants.Errors.cs
@@ -11,6 +11,14 @@ namespace Hive
       /// The error message when no request processing pipeline has been configured
       /// </summary>
       public const string PipelineNotSet = "No pipeline has been configured. Aborting";
+
+      /// <summary>
+      /// The error message format when ASPNETCORE_ENVIRONMENT and DOTNET_ENVIRONMENT are both set to conflicting values.
+      /// {0} = ASPNETCORE_ENVIRONMENT value, {1} = DOTNET_ENVIRONMENT value.
+      /// </summary>
+      public const string EnvironmentVariableConflict =
+        "Environment variable conflict: ASPNETCORE_ENVIRONMENT='{0}' and DOTNET_ENVIRONMENT='{1}' are set to different values. " +
+        "Hive honors ASPNETCORE_ENVIRONMENT for configuration loading. Resolve the conflict before starting the service.";
     }
   }
 }

--- a/hive.core/src/Hive.Abstractions/EnvironmentVariableConflictDetector.cs
+++ b/hive.core/src/Hive.Abstractions/EnvironmentVariableConflictDetector.cs
@@ -1,0 +1,36 @@
+namespace Hive;
+
+/// <summary>
+/// Detects conflicting values between ASPNETCORE_ENVIRONMENT and DOTNET_ENVIRONMENT.
+/// </summary>
+internal static class EnvironmentVariableConflictDetector
+{
+  private static readonly System.Text.CompositeFormat ConflictFormat =
+    System.Text.CompositeFormat.Parse(Constants.Errors.EnvironmentVariableConflict);
+
+  /// <summary>
+  /// Returns a conflict message when both environment variables are set to case-insensitively different values,
+  /// or <c>null</c> when there is no conflict.
+  /// </summary>
+  /// <param name="aspNetCoreEnvironment">Value of ASPNETCORE_ENVIRONMENT, or null/empty if not set.</param>
+  /// <param name="dotNetEnvironment">Value of DOTNET_ENVIRONMENT, or null/empty if not set.</param>
+  /// <returns>A self-sufficient conflict message, or <c>null</c> when no conflict is detected.</returns>
+  internal static string? Detect(string? aspNetCoreEnvironment, string? dotNetEnvironment)
+  {
+    if (string.IsNullOrEmpty(aspNetCoreEnvironment) || string.IsNullOrEmpty(dotNetEnvironment))
+    {
+      return null;
+    }
+
+    if (string.Equals(aspNetCoreEnvironment, dotNetEnvironment, StringComparison.OrdinalIgnoreCase))
+    {
+      return null;
+    }
+
+    return string.Format(
+      System.Globalization.CultureInfo.InvariantCulture,
+      ConflictFormat,
+      aspNetCoreEnvironment,
+      dotNetEnvironment);
+  }
+}

--- a/hive.core/src/Hive.Abstractions/Hive.Abstractions.csproj
+++ b/hive.core/src/Hive.Abstractions/Hive.Abstractions.csproj
@@ -15,6 +15,11 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Hive.Abstractions.Tests" />
+    <InternalsVisibleTo Include="Hive.MicroServices" />
+  </ItemGroup>
+
 	<ItemGroup>
 		<PackageReference Include="FluentValidation" />
 		<PackageReference Include="Microsoft.AspNetCore.MiddlewareAnalysis" />

--- a/hive.core/tests/Hive.Abstractions.Tests/EnvironmentVariableConflictDetectorTests.cs
+++ b/hive.core/tests/Hive.Abstractions.Tests/EnvironmentVariableConflictDetectorTests.cs
@@ -1,0 +1,103 @@
+using CloudTek.Testing;
+using FluentAssertions;
+using Xunit;
+
+namespace Hive.Abstractions.Tests;
+
+public class EnvironmentVariableConflictDetectorTests
+{
+  [Fact]
+  [UnitTest]
+  public void GivenBothNull_WhenDetect_ThenReturnsNull()
+  {
+    // Act
+    var result = EnvironmentVariableConflictDetector.Detect(null, null);
+
+    // Assert
+    result.Should().BeNull();
+  }
+
+  [Fact]
+  [UnitTest]
+  public void GivenOnlyAspNetCoreEnvironmentSet_WhenDetect_ThenReturnsNull()
+  {
+    // Act
+    var result = EnvironmentVariableConflictDetector.Detect("Development", null);
+
+    // Assert
+    result.Should().BeNull();
+  }
+
+  [Fact]
+  [UnitTest]
+  public void GivenOnlyDotNetEnvironmentSet_WhenDetect_ThenReturnsNull()
+  {
+    // Act
+    var result = EnvironmentVariableConflictDetector.Detect(null, "Development");
+
+    // Assert
+    result.Should().BeNull();
+  }
+
+  [Fact]
+  [UnitTest]
+  public void GivenBothSetToSameValue_WhenDetect_ThenReturnsNull()
+  {
+    // Act
+    var result = EnvironmentVariableConflictDetector.Detect("Development", "Development");
+
+    // Assert
+    result.Should().BeNull();
+  }
+
+  [Fact]
+  [UnitTest]
+  public void GivenBothSetToSameValueDifferentCasing_WhenDetect_ThenReturnsNull()
+  {
+    // Act
+    var result = EnvironmentVariableConflictDetector.Detect("Development", "development");
+
+    // Assert
+    result.Should().BeNull();
+  }
+
+  [Fact]
+  [UnitTest]
+  public void GivenBothSetToDifferentValues_WhenDetect_ThenReturnsMessageNamingBothVariables()
+  {
+    // Act
+    var result = EnvironmentVariableConflictDetector.Detect("Development", "Production");
+
+    // Assert
+    result.Should().NotBeNull();
+    result.Should().Contain("ASPNETCORE_ENVIRONMENT");
+    result.Should().Contain("DOTNET_ENVIRONMENT");
+    result.Should().Contain("Development");
+    result.Should().Contain("Production");
+  }
+
+  [Fact]
+  [UnitTest]
+  public void GivenBothSetToDifferentValues_WhenDetect_ThenMessageMentionsHiveHonorsAspNetCoreEnvironment()
+  {
+    // Act
+    var result = EnvironmentVariableConflictDetector.Detect("Development", "Production");
+
+    // Assert
+    result.Should().Contain("ASPNETCORE_ENVIRONMENT");
+  }
+
+  [Theory]
+  [UnitTest]
+  [InlineData("", "Production")]
+  [InlineData("Development", "")]
+  [InlineData("", "")]
+  public void GivenEmptyValues_WhenDetect_ThenReturnsNull(string? aspNetCore, string? dotNet)
+  {
+    // Act
+    var result = EnvironmentVariableConflictDetector.Detect(aspNetCore, dotNet);
+
+    // Assert
+    result.Should().BeNull();
+  }
+}

--- a/hive.microservices/src/Hive.MicroServices/MicroService.cs
+++ b/hive.microservices/src/Hive.MicroServices/MicroService.cs
@@ -122,6 +122,16 @@ public partial class MicroService : MicroServiceBase, IMicroService
   {
     Activity.DefaultIdFormat = ActivityIdFormat.W3C;
 
+    EnvironmentVariables.TryGetValue(Constants.EnvironmentVariables.DotNet.Environment, out var aspNetCoreEnv);
+    EnvironmentVariables.TryGetValue(Constants.EnvironmentVariables.DotNet.RuntimeEnvironment, out var dotNetEnv);
+
+    var conflictMessage = EnvironmentVariableConflictDetector.Detect(aspNetCoreEnv, dotNetEnv);
+    if (conflictMessage != null)
+    {
+      Logger.LogEnvironmentVariableConflict(conflictMessage);
+      throw new ConfigurationException(conflictMessage);
+    }
+
     if (ExternalHostFactory != null)
     {
       var config = configuration ?? new ConfigurationBuilder().Build();

--- a/hive.microservices/src/Hive.MicroServices/MicroServiceLogEventId.cs
+++ b/hive.microservices/src/Hive.MicroServices/MicroServiceLogEventId.cs
@@ -43,6 +43,11 @@ public enum MicroServiceLogEventId
   ServiceStartupCriticalFailure = 110,
 
   /// <summary>
+  /// ASPNETCORE_ENVIRONMENT and DOTNET_ENVIRONMENT are set to conflicting values
+  /// </summary>
+  EnvironmentVariableConflict = 111,
+
+  /// <summary>
   /// A hosted startup service has completed
   /// </summary>
   HostedStartupServiceCompleted = 120,

--- a/hive.microservices/src/Hive.MicroServices/MicroServiceLogExtensions.cs
+++ b/hive.microservices/src/Hive.MicroServices/MicroServiceLogExtensions.cs
@@ -4,6 +4,9 @@ namespace Hive.MicroServices;
 
 internal static partial class MicroServiceLogExtensions
 {
+  [LoggerMessage((int)MicroServiceLogEventId.EnvironmentVariableConflict, LogLevel.Critical, "Environment variable conflict detected: {Message}")]
+  internal static partial void LogEnvironmentVariableConflict(this ILogger logger, string message);
+
   [LoggerMessage((int)MicroServiceLogEventId.UnhandledException, LogLevel.Critical, "Unhandled exception in {Service}")]
   internal static partial void LogUnhandledException(this ILogger logger, string service, Exception ex);
 }

--- a/hive.microservices/tests/Hive.MicroServices.Tests/Hive.MicroServices.Tests.csproj
+++ b/hive.microservices/tests/Hive.MicroServices.Tests/Hive.MicroServices.Tests.csproj
@@ -33,6 +33,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Remove="cors-config-01.json.cs" />
     <EmbeddedResource Include="cors-config-01.json" />
     <EmbeddedResource Include="cors-config-02.json" />

--- a/hive.microservices/tests/Hive.MicroServices.Tests/MicroServiceTests.Environment.cs
+++ b/hive.microservices/tests/Hive.MicroServices.Tests/MicroServiceTests.Environment.cs
@@ -1,0 +1,98 @@
+using System.Threading.Tasks;
+using CloudTek.Testing;
+using FluentAssertions;
+using Hive.Exceptions;
+using Hive.MicroServices.Extensions;
+using Hive.MicroServices.Testing;
+using Hive.Testing;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Hive.MicroServices.Tests;
+
+public partial class MicroServiceTests
+{
+  public class Environment
+  {
+    private const string ServiceName = "microservice-tests-environment";
+
+    [Fact]
+    [UnitTest]
+    public async Task GivenOnlyAspNetCoreEnvironmentSet_WhenInitializeAsync_ThenNoConflictThrown()
+    {
+      // Arrange — DOTNET_ENVIRONMENT cleared (empty) so only ASPNETCORE_ENVIRONMENT is effective
+      using var aspScope = EnvironmentVariableScope.Create(Constants.EnvironmentVariables.DotNet.Environment, "Development");
+      using var dotScope = EnvironmentVariableScope.Create(Constants.EnvironmentVariables.DotNet.RuntimeEnvironment, "");
+
+      var config = new ConfigurationBuilder().Build();
+      var service = new MicroService(ServiceName)
+        .InTestClass<MicroServiceTests>()
+        .ConfigureTestHost();
+
+      // Act
+      var action = async () => await service.InitializeAsync(config);
+
+      // Assert
+      await action.Should().NotThrowAsync<ConfigurationException>();
+    }
+
+    [Fact]
+    [UnitTest]
+    public async Task GivenOnlyDotNetEnvironmentSet_WhenInitializeAsync_ThenNoConflictThrown()
+    {
+      // Arrange — ASPNETCORE_ENVIRONMENT cleared (empty) so only DOTNET_ENVIRONMENT is effective
+      using var aspScope = EnvironmentVariableScope.Create(Constants.EnvironmentVariables.DotNet.Environment, "");
+      using var dotScope = EnvironmentVariableScope.Create(Constants.EnvironmentVariables.DotNet.RuntimeEnvironment, "Development");
+
+      var config = new ConfigurationBuilder().Build();
+      var service = new MicroService(ServiceName)
+        .InTestClass<MicroServiceTests>()
+        .ConfigureTestHost();
+
+      // Act
+      var action = async () => await service.InitializeAsync(config);
+
+      // Assert
+      await action.Should().NotThrowAsync<ConfigurationException>();
+    }
+
+    [Fact]
+    [UnitTest]
+    public async Task GivenBothSetToSameValueDifferentCasing_WhenInitializeAsync_ThenNoConflictThrown()
+    {
+      // Arrange — same environment, different case
+      using var aspScope = EnvironmentVariableScope.Create(Constants.EnvironmentVariables.DotNet.Environment, "Development");
+      using var dotScope = EnvironmentVariableScope.Create(Constants.EnvironmentVariables.DotNet.RuntimeEnvironment, "development");
+
+      var config = new ConfigurationBuilder().Build();
+      var service = new MicroService(ServiceName)
+        .InTestClass<MicroServiceTests>()
+        .ConfigureTestHost();
+
+      // Act
+      var action = async () => await service.InitializeAsync(config);
+
+      // Assert
+      await action.Should().NotThrowAsync<ConfigurationException>();
+    }
+
+    [Fact]
+    [UnitTest]
+    public async Task GivenBothSetToDifferentValues_WhenInitializeAsync_ThenThrowsConfigurationExceptionNamingBothVariables()
+    {
+      // Arrange — genuinely conflicting environment values
+      using var aspScope = EnvironmentVariableScope.Create(Constants.EnvironmentVariables.DotNet.Environment, "Development");
+      using var dotScope = EnvironmentVariableScope.Create(Constants.EnvironmentVariables.DotNet.RuntimeEnvironment, "Production");
+
+      var service = new MicroService(ServiceName)
+        .InTestClass<MicroServiceTests>();
+
+      // Act & Assert
+      var ex = await service.Invoking(s => s.InitializeAsync())
+        .Should().ThrowAsync<ConfigurationException>();
+
+      ex.And.Message.Should().Contain("ASPNETCORE_ENVIRONMENT");
+      ex.And.Message.Should().Contain("DOTNET_ENVIRONMENT");
+    }
+  }
+}

--- a/hive.microservices/tests/Hive.MicroServices.Tests/xunit.runner.json
+++ b/hive.microservices/tests/Hive.MicroServices.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeTestCollections": false
+}


### PR DESCRIPTION
## Summary

Second PR of the **10.1.1 safety patch** (PR-1 was the Logger NRE fix). Resolves [#66](https://github.com/cloud-tek/hive/issues/66) plus two pieces of build hygiene that surfaced while running the full `cloudtek-build --target All` gate.

### 1. `fix:` env-var conflict fail-fast (#66)
`MicroServiceBase` only honors `ASPNETCORE_ENVIRONMENT` for config loading, while the underlying host also reads `DOTNET_ENVIRONMENT`. When both were set to **different** values the divergence was silent.

- `InitializeAsync` now detects a case-insensitive conflict via a pure, internal detector in `Hive.Abstractions` (`EnvironmentVariableConflictDetector`).
- On conflict: emits a `[LoggerMessage]` diagnostic (event id 111, Critical), then throws `ConfigurationException`.
- The exception message names **both** variables, **both** values, and states Hive honors `ASPNETCORE_ENVIRONMENT`:
  > `Environment variable conflict: ASPNETCORE_ENVIRONMENT='Development' and DOTNET_ENVIRONMENT='Production' are set to different values. Hive honors ASPNETCORE_ENVIRONMENT for configuration loading. Resolve the conflict before starting the service.`
- **Additive only** — configuration source ordering/precedence is unchanged (env vars + command line stay highest precedence).
- **Deferred (out of scope):** realigning the `Environment` property to also read `DOTNET_ENVIRONMENT` (a behavior change for a later minor/major).

### 2. `chore:` bump `CloudTek.Sdk` to stable `10.0.0`
The SDK issue is fixed and `10.0.0` is published; moves off the `10.0.0-beta.5` pin and retires the `OutdatedCheck`/beta-check caveat from PR-1.

### 3. `fix:` pin `MessagePack` 2.5.302 (clears GHSA-hv8m-jj95-wg3x)
`MessagePack 2.5.192` was pulled transitively into the Aspire demo apphost (`Aspire.Hosting → StreamJsonRpc`) and tripped `NU1903` (warnings-as-errors) at restore — a **pre-existing** failure unrelated to #66. Central transitive pinning is already enabled, so one `PackageVersion` override clears the high-severity advisory solution-wide.

## Tests
- 10 pure detector unit tests (`EnvironmentVariableConflictDetectorTests`).
- 4 `InitializeAsync` matrix tests (`MicroServiceTests.Environment`): only-ASP / only-DOTNET / both-equal-different-casing → start OK; both-different → throws naming both vars.
- A `xunit.runner.json` (`parallelizeTestCollections: false`) serializes env-var-mutating test collections to avoid races with the CORS tests.

## Verification
- Full `cloudtek-build --target All` gate: **all targets green** (Restore, Format/Analyzer checks, OutdatedCheck, BetaCheck, Compile, Unit + Integration tests, Pack).
- `Hive.MicroServices.Tests` 49/49; Startup regression 11/11.

## Notes for reviewers
- No version bump in this PR — `Version.targets` is already `10.1.1` (set by PR-1).
- `xunit.runner.json` disables collection parallelism assembly-wide (~13s for 49 tests). Could be narrowed to a `[Collection]` grouping if preferred.
- The MessagePack pin is technically beyond #66's scope but rides in the same safety-patch spirit; isolated in its own commit if you'd rather split it.