### PR TITLE
feat(#64): MapEndpoints seam + pipeline-mode docs (#65) (10.2.0)

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -53,6 +53,40 @@ Hive uses a two-tier interface hierarchy to support different hosting models:
 - Functions execution: `RunAsync(CancellationToken) → Task`
 - Use when: Building Azure Functions with Hive framework
 
+## Internal Pipeline State & the `(MicroService)` Downcast Convention
+
+`MicroService` is the **sole concrete implementation** of `IMicroService`. The fluent
+configuration extension methods (`ConfigureApiPipeline`, `ConfigureGraphQLPipeline`,
+`ConfigureGrpcPipeline`, `ConfigureMcpPipeline`, `ConfigureJob`,
+`ConfigureDefaultServicePipeline`, `MapEndpoints`, …) accumulate work into **internal**
+list-of-actions state on `MicroService`:
+
+- `internal List<Action<IServiceCollection, IConfiguration>> ConfigureActions`
+- `internal List<Action<IApplicationBuilder>> ConfigurePipelineActions`
+- `internal List<Action<IEndpointRouteBuilder>> MapEndpointActions`
+
+Because these lists are framework-internal, the extension methods reach them via a
+**`(MicroService)microservice` downcast** from the public `IMicroService` parameter. This is
+the **deliberate, framework-wide idiom** (used at ~11 sites across every pipeline-mode
+extension and the core helpers), not an oversight.
+
+**This is intentional — do not "fix" it.** Reviewers (human or automated) sometimes flag the
+downcast as an LSP violation. The alternatives are worse for this codebase:
+
+- **Lifting the lists onto `IMicroService`** leaks mutable, framework-internal plumbing onto a
+  public, Kubernetes-facing interface — an ISP/encapsulation violation.
+- **Introducing an `IMicroServiceInternal` seam** is unwarranted churn for a sole-implementation
+  framework (YAGNI); `InternalsVisibleTo` plus the single-implementation reality already provide
+  the needed guarantees.
+
+Internal helpers that consume this state (e.g. `DrainCustomEndpoints(this IEndpointRouteBuilder,
+MicroService)`) likewise take the **concrete `MicroService`** type by design, since they read
+internal members. No per-site explanatory comment is expected — this convention is the
+explanation.
+
+**Revisit trigger:** if a *second* concrete `IMicroService` implementation is ever introduced,
+re-evaluate this convention (an internal interface seam would then become justified).
+
 ## Extension Pattern
 
 All framework features are implemented as extensions inheriting from `MicroServiceExtension<T>`. Extensions participate in the service lifecycle through:

--- a/README.md
+++ b/README.md
@@ -448,6 +448,8 @@ Hive uses custom xUnit attributes for test categorization:
 
 ## Documentation
 
+For the full documentation index — design docs, topic guides, build reference, and all package READMEs — see **[docs/README.md](./docs/README.md)**.
+
 ### Project Documentation
 
 - [CLAUDE.md](./CLAUDE.md) - Comprehensive project guide for Claude Code

--- a/Version.targets
+++ b/Version.targets
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>10.1.1</VersionPrefix>
+        <VersionPrefix>10.2.0</VersionPrefix>
     </PropertyGroup>
 </Project>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,114 @@
+# Hive Documentation Index
+
+This is the central index for all Hive documentation.
+For the project overview and quick-start, see the [root README](../README.md).
+
+---
+
+## Contents
+
+- [Getting Started](#getting-started)
+- [Build & CI Reference](#build--ci-reference)
+- [Design Documents](#design-documents)
+- [Plans](#plans)
+- [Topic Guides](#topic-guides)
+- [Package & Extension READMEs](#package--extension-readmes)
+
+---
+
+## Getting Started
+
+See [getting-started.md](getting-started.md) for a step-by-step guide to building your first Hive service.
+
+The root [README Quick Start](../README.md#quick-start) also covers basic REST API and configuration examples.
+
+---
+
+## Build & CI Reference
+
+See [build.md](build.md) for the full reference of `cloudtek-build` targets and `dotnet` CLI equivalents.
+
+**Quick reference:**
+
+```bash
+# Full build (all targets, including checks)
+dotnet tool run cloudtek-build --target All
+
+# Quick build (skip checks — useful during development)
+dotnet tool run cloudtek-build --target All --Skip RunChecks
+
+# Build with dotnet CLI
+dotnet build Hive.sln
+
+# Run all tests
+dotnet test Hive.sln
+
+# Run tests by category
+dotnet test --filter Category=UnitTests
+dotnet test --filter Category=IntegrationTests
+dotnet test --filter Category=ModuleTests
+dotnet test --filter Category=SmokeTests
+dotnet test --filter Category=SystemTests
+```
+
+---
+
+## Design Documents
+
+Documents in [`design/`](design/) capture architectural decisions and analysis.
+
+| Document | Description |
+|---|---|
+| [aspire_integration_design.md](design/aspire_integration_design.md) | Draft design for integrating Hive with .NET Aspire orchestration |
+| [cors_extraction_analysis.md](design/cors_extraction_analysis.md) | Analysis of whether CORS should be extracted to `Hive.Abstractions` for cross-host reuse |
+| [custom_endpoints_seam_design.md](design/custom_endpoints_seam_design.md) | Accepted design for the `MapEndpoints` extension seam (PR-3, 10.2.0 milestone) |
+| [hive_functions_design.md](design/hive_functions_design.md) | Draft design for the Azure Functions integration (`Hive.Functions`) |
+| [otel_configuration_strategy.md](design/otel_configuration_strategy.md) | Strategy for declarative OpenTelemetry configuration via `appsettings.json` |
+
+---
+
+## Plans
+
+Documents in [`plan/`](plan/) track implementation status and handoff notes.
+
+| Document | Description |
+|---|---|
+| [open_issues_implementation_plan.md](plan/open_issues_implementation_plan.md) | Consolidated implementation plan covering issues #62, #64, #65, #66 and their release groupings |
+| [pr1_logger_nre_handoff.md](plan/pr1_logger_nre_handoff.md) | Handoff note for the Logger NRE bug fix shipped in 10.1.1 (PR-1 of issue #64) |
+
+---
+
+## Topic Guides
+
+Focused deep-dives on specific concerns.
+
+| Document | Description |
+|---|---|
+| [dagger.md](dagger.md) | Workaround for the 128 MB `File.Contents()` limit in the Dagger-based CI validate workflow |
+| [healthchecks.md](healthchecks.md) | Design notes for the threshold-based readiness gating system in `Hive.HealthChecks` |
+| [http.md](http.md) | Design and usage guide for `Hive.HTTP` typed HTTP clients (Refit, resilience, telemetry) |
+| [messaging.md](messaging.md) | Design notes for the `Hive.Messaging` extension built on Wolverine |
+| [optimization.md](optimization.md) | Code duplication and optimization analysis for `Hive.HealthChecks` |
+| [otel-aspire.md](otel-aspire.md) | Implemented guide for OpenTelemetry Collector integration with Aspire and VictoriaMetrics |
+
+---
+
+## Package & Extension READMEs
+
+| Package | Purpose |
+|---|---|
+| [Hive.Abstractions & Hive.Testing](../hive.core/readme.md) | Foundation layer — core interfaces, extension base classes, xUnit test attributes |
+| [Hive.MicroServices](../hive.microservices/src/Hive.MicroServices/README.md) | Core ASP.NET Core orchestration framework — lifecycle, pipeline modes, Kubernetes probes |
+| [Hive.MicroServices.Api](../hive.microservices/README.md#hive.microservicesapi) | REST API support — minimal APIs and MVC controllers |
+| [Hive.MicroServices.GraphQL](../hive.microservices/README.md#hive.microservicesgraphql) | GraphQL API support via HotChocolate |
+| [Hive.MicroServices.Grpc](../hive.microservices/README.md#hive.microservicesgrpc) | gRPC service support (protobuf-first) |
+| [Hive.MicroServices.Mcp](../hive.microservices/src/Hive.MicroServices.Mcp/README.md) | MCP (Model Context Protocol) server support — expose tools/data to LLM clients |
+| [Hive.MicroServices.Job](../hive.microservices/README.md#hive.microservicesjob) | Background worker and scheduled job support |
+| [Hive.MicroServices.Testing](../hive.microservices/src/Hive.MicroServices.Testing/README.md) | TestServer integration testing utilities |
+| [CORS](../hive.microservices/src/Hive.MicroServices/CORS/README.md) | CORS configuration guide — policies, security best practices, validation |
+| [Hive.HTTP](../hive.extensions/src/Hive.HTTP/README.md) | Typed HTTP clients with Refit, resilience, and OpenTelemetry instrumentation |
+| [Hive.HealthChecks](../hive.extensions/src/Hive.HealthChecks/README.md) | Threshold-based readiness gating with background health monitoring |
+| [Hive.Messaging](../hive.extensions/src/Hive.Messaging/README.md) | Wolverine-based messaging with RabbitMQ transport and readiness middleware |
+| [Hive.OpenTelemetry](../hive.opentelemetry/README.md) | Unified logs, traces, and metrics via OTLP — zero-config defaults |
+| [Hive.Functions](../hive.functions/README.md) | Azure Functions Worker integration following the Hive extension pattern |
+| [hive.extensions module](../hive.extensions/README.md) | Module-level README covering HTTP, Messaging, and HealthChecks together |

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,0 +1,100 @@
+# Build & CI Reference
+
+All build targets run via `CloudTek.Build.Tool` (`cloudtek-build`), which is declared in `.config/dotnet-tools.json` at version `10.0.0`.
+
+---
+
+## Restore the build tool
+
+```bash
+dotnet tool restore
+```
+
+---
+
+## CloudTek.Build.Tool targets
+
+| Command | What it does |
+|---|---|
+| `dotnet tool run cloudtek-build --target All` | Full build: compile, test, and all checks (outdated packages, formatting, etc.) |
+| `dotnet tool run cloudtek-build --target All --Skip RunChecks` | Compile and test only — skips the `RunChecks` phase (faster for local iteration) |
+
+The `--Skip` flag accepts a comma-separated list of target names to exclude.
+
+---
+
+## dotnet CLI equivalents
+
+Use these when the build tool is not available or for targeted operations.
+
+### Build
+
+```bash
+# Entire solution
+dotnet build Hive.sln
+
+# Release configuration
+dotnet build Hive.sln -c Release
+
+# Single project
+dotnet build hive.microservices/src/Hive.MicroServices/Hive.MicroServices.csproj
+```
+
+### Test
+
+```bash
+# All tests
+dotnet test Hive.sln
+
+# By category (xUnit trait filter)
+dotnet test Hive.sln --filter Category=UnitTests
+dotnet test Hive.sln --filter Category=IntegrationTests
+dotnet test Hive.sln --filter Category=ModuleTests
+dotnet test Hive.sln --filter Category=SmokeTests
+dotnet test Hive.sln --filter Category=SystemTests
+
+# Single test by fully-qualified name
+dotnet test Hive.sln --filter FullyQualifiedName~MyTestClass.MyTestMethod
+```
+
+### Test category attributes
+
+Hive defines custom xUnit attributes in `CloudTek.Testing` (exposed via `Hive.Testing`):
+
+| Attribute | `Category` value | Typical use |
+|---|---|---|
+| `[UnitTest]` | `UnitTests` | Fast, in-process, no I/O |
+| `[IntegrationTest]` | `IntegrationTests` | Real dependencies or TestServer |
+| `[ModuleTest]` | `ModuleTests` | Module-scope cross-cutting tests |
+| `[SmokeTest]` | `SmokeTests` | Quick sanity checks |
+| `[SystemTest]` | `SystemTests` | End-to-end against a running service |
+
+---
+
+## Running demo applications
+
+```bash
+# REST API demo
+dotnet run --project hive.microservices/demo/Hive.MicroServices.Demo.Api
+
+# All demos via Aspire orchestration
+dotnet run --project hive.microservices/demo/Hive.MicroServices.Demo.Aspire
+```
+
+---
+
+## Centralized package management
+
+All NuGet package versions are declared in `Directory.Packages.props` (`ManagePackageVersionsCentrally=true`). Project files reference packages without a `Version` attribute. To add a new package:
+
+1. Add a `<PackageVersion Include="..." Version="..." />` entry to `Directory.Packages.props`.
+2. Add `<PackageReference Include="..." />` (no version) to the target `.csproj`.
+
+Version source of truth for Hive's own packages: [`Version.targets`](../Version.targets).
+
+---
+
+## CI notes
+
+- The Dagger-based CI `validate` workflow has a 128 MB patch limit when `--auto-apply` is used. See [dagger.md](dagger.md) for the workaround.
+- Outdated-package checks run as part of `RunChecks`; skip with `--Skip RunChecks` to avoid failures caused by upstream releases during development.

--- a/docs/design/custom_endpoints_seam_design.md
+++ b/docs/design/custom_endpoints_seam_design.md
@@ -1,0 +1,394 @@
+# Custom Endpoints Seam — `MapEndpoints` Design
+
+**Date**: 2026-06-21
+**Status**: Accepted — design gate for PR-3 of the 10.2.0 milestone; both open questions resolved by the human (see [§10](#10-resolved-decisions))
+**Issue**: [#64 "main"](https://github.com/cloud-tek/hive/issues/64) — general `MapEndpoints` seam ("Option 3")
+**Version impact**: minor bump to **10.2.0** (currently `Version.targets` = `10.1.1`). This document does **not** change `Version.targets`.
+
+---
+
+## TL;DR Recommendation
+
+Add a mode-agnostic seam:
+
+```csharp
+public static IMicroService MapEndpoints(
+  this IMicroService microservice,
+  Action<IEndpointRouteBuilder> map);
+```
+
+backed by new internal state on `MicroService`:
+
+```csharp
+internal List<Action<IEndpointRouteBuilder>> MapEndpointActions { get; } = new();
+```
+
+Each mode's `UseEndpoints(...)` block **drains `MapEndpointActions` immediately after mapping its own endpoints**, so custom routes ride inside the **same** `UseRouting → (UseCors) → UseAuthorization → UseEndpoints` envelope as the mode's endpoints. The change is **additive and non-breaking**; the `PipelineMode` set-once invariant is untouched (routes are orthogonal to mode).
+
+**Two human decisions are now locked (see [§10](#10-resolved-decisions)):**
+
+- **Job services FORBID custom HTTP routes.** `MapEndpoints` stays a pure recorder, but the **Job pipeline-build delegate throws** `ConfigurationException` if `MapEndpointActions` is non-empty when the Job pipeline is constructed. This trades the recorder's "always works on any mode" guarantee — for Job specifically — for a deterministic startup-time failure. The guard keys off the **Job pipeline-build path**, not the `None` enum value.
+- **Bare `None` (`ConfigureDefaultServicePipeline`) DRAINS and serves custom routes**, symmetric with the HTTP modes. Note the deliberate asymmetry: both Job and Default resolve to `PipelineMode.None`, yet Default serves custom routes and Job rejects them. The distinction is **Job intent, expressed at the Job pipeline-build site**, not the mode enum.
+
+On the shared-helper question: **do the lighter-touch per-mode drain now, not the full envelope extraction.** Per-mode asymmetries (Api-minimal's Swagger dev pipeline routed through a private `ConfigureApiPipelineInternal`, gRPC's catch-all `MapGet("/")`, Job/None's placeholder route) mean a single shared envelope helper would have to grow parameters to re-introduce exactly the per-mode variation it tries to remove. A one-line drain call in each existing `UseEndpoints` block delivers the seam with far less churn and risk. Full extraction is recorded as **deferred** (see [§9](#9-deferred--out-of-scope)).
+
+---
+
+## 1. Problem
+
+Hive's pipeline modes are mutually exclusive. `MicroService.PipelineMode` is `set-once`, guarded by `ValidatePipelineModeNotSet()`:
+
+```csharp
+// hive.microservices/src/Hive.MicroServices/Extensions/IMicroServiceExtensions.cs:134
+internal static IMicroService ValidatePipelineModeNotSet(this IMicroService microservice)
+{
+  var service = (MicroService)microservice;
+  if (service.PipelineMode != MicroServicePipelineMode.NotSet)
+  {
+    throw new InvalidOperationException($"MicroService {nameof(service.PipelineMode)} is already set");
+  }
+  return microservice;
+}
+```
+
+A service that selects one mode (`Api`, `ApiControllers`, `GraphQL`, `Grpc`, `Mcp`) has **no first-class way to ALSO expose auxiliary HTTP routes** — control-plane endpoints, webhooks, admin actions — on the same service.
+
+The only current workaround is a fragile, undocumented ordering trick: register a custom `MicroServiceExtension` and use its `Configure(app)` override to call `app.UseEndpoints(...)` (or map routes directly on `app`). This happens to work **only** because `ConfigureExtensions()` appends `extension.Configure(app, this)` to `ConfigurePipelineActions` *before* the mode's routing block is appended:
+
+```csharp
+// hive.microservices/src/Hive.MicroServices/MicroService.InternalExtensions.cs:12
+internal MicroService ConfigureExtensions()
+{
+  Extensions.ForEach(extension =>
+  {
+    ConfigureActions.Add((services, configuration) => extension.ConfigureServices(services, this));
+    ConfigurePipelineActions.Add((app) => extension.Configure(app, this));   // appended BEFORE the mode's routing block
+  });
+  return this;
+}
+```
+
+That ordering is incidental, not contractual. It places custom routes in a **separate** routing pass outside the mode's `UseRouting → CORS → UseAuthorization` envelope, which means CORS and authorization may not apply consistently. It is exactly the kind of seam that should be promoted to a first-class, documented API.
+
+---
+
+## 2. Grounding in the actual code
+
+Every HTTP-capable path independently hand-rolls the same envelope via `service.ConfigurePipelineActions.Add(app => { ... })`. The canonical clean example is MCP:
+
+```csharp
+// hive.microservices/src/Hive.MicroServices.Mcp/IMicroServiceExtensions.cs:38-58
+service
+    .ConfigureExtensions()
+    .ConfigurePipelineActions.Add(app =>
+{
+  app.UseRouting();
+
+  var corsExtension = microservice.Extensions.SingleOrDefault(x => x is CORS.Extension);
+  if (corsExtension is not null)
+  {
+    app.UseCors();
+  }
+
+  app.UseAuthorization();
+  app.UseEndpoints(endpoints =>
+    {
+      endpoints.MapMcp();
+    });
+});
+
+service.PipelineMode = MicroServicePipelineMode.Mcp;
+```
+
+The exhaustive list of consumers (verified via grep over `ConfigurePipelineActions` / `ValidatePipelineModeNotSet` / `PipelineMode` setters):
+
+| Site | File | `UseEndpoints` body | `PipelineMode` set | HTTP? |
+|---|---|---|---|---|
+| Api minimal | `Hive.MicroServices.Api/IMicroServiceExtensions.cs:50` (`ConfigureApiPipelineInternal`) | user `endpointBuilder` | `Api` (set by caller, **after** internal) | yes |
+| ApiControllers | same internal | `endpoints.MapControllers()` | `ApiControllers` (after internal) | yes |
+| GraphQL | `Hive.MicroServices.GraphQL/IMicroServiceExtensions.cs:45` | `endpoints.MapGraphQL("/graphql")` | `GraphQL` | yes |
+| gRPC / code-first gRPC | `Hive.MicroServices.Grpc/IMicroServiceExtensions.cs:36` | user builder **plus** catch-all `MapGet("/")` | `Grpc` | yes |
+| MCP | `Hive.MicroServices.Mcp/IMicroServiceExtensions.cs:38` | `endpoints.MapMcp()` | `Mcp` | yes |
+| Job | `Hive.MicroServices.Job/IMicroServiceExtensions.cs:34` | placeholder `MapGet("/")` | **`None`** | **yes** |
+| Default pipeline | `Hive.MicroServices/Extensions/IMicroServiceExtensions.cs:151` (`ConfigureDefaultServicePipeline`) | `MapGet("/*")` → 404 | **`None`** | **yes** |
+
+### Asymmetries that matter
+
+1. **Api-minimal vs the rest.** `ConfigureApiPipeline` and `ConfigureApiControllerPipeline` both delegate to a private `ConfigureApiPipelineInternal`, which also wires a **development-only Swagger pipeline** via `UseCoreMicroServicePipeline(developmentOnlyPipeline: ...)`. The `PipelineMode` is set by the **public** method *after* the internal runs — the only mode where the assignment is split from the envelope construction. The envelope shape itself is identical to the others.
+
+2. **`None` is not "non-HTTP".** This is the biggest divergence from the plan's framing. **Job sets `PipelineMode.None` yet builds a full HTTP envelope** (`UseRouting → CORS → UseAuthorization → UseEndpoints`) and serves a placeholder `/`. `ConfigureDefaultServicePipeline` *also* sets `None` and serves a 404 catch-all. So `None` denotes "no *application* request-processing mode," **not** "no HTTP host." Every shipped path that sets a mode — including Job and Default — has a live `UseEndpoints` block.
+
+3. **gRPC** appends its own catch-all `MapGet("/")` *after* the user builder inside the same `UseEndpoints`. Any drained custom routes must be ordered carefully relative to that catch-all (see [§4.1](#41-decision-1--ordering)).
+
+4. **CORS is conditional and `IMicroService`-only.** Every site repeats the identical `SingleOrDefault(x => x is CORS.Extension)` probe and calls `app.UseCors()` only when the extension is present. `CORS.Extension.Create` throws if the host is not an `IMicroService`. CORS application is therefore already a per-mode conditional, not a guaranteed envelope stage.
+
+5. **The `(MicroService)microservice` cast is the established idiom.** Every mode extension, and core helpers like `UseCoreMicroServicePipeline` and `ValidatePipelineModeNotSet`, cast `IMicroService → MicroService` to reach internal state. The plan's sketch is consistent with the codebase. Mode assemblies already have `InternalsVisibleTo` (see [§6](#6-internalsvisibleto--testability)), so they can read the new `MapEndpointActions` directly.
+
+---
+
+## 3. Options considered
+
+### Option A — Lighter-touch per-mode drain (RECOMMENDED)
+
+Add `MapEndpoints` + `MapEndpointActions`. In each existing `UseEndpoints(...)` body, after the mode maps its own endpoints, drain the list:
+
+```csharp
+app.UseEndpoints(endpoints =>
+{
+  endpoints.MapMcp();                                  // mode endpoints first
+  foreach (var map in service.MapEndpointActions)      // then custom routes
+  {
+    map(endpoints);
+  }
+});
+```
+
+- **Pros**: minimal churn (one loop per site); preserves each mode's exact existing behavior including the Api-minimal split, gRPC catch-all ordering, and conditional CORS; trivially reviewable; KISS/YAGNI-aligned.
+- **Cons**: the drain line is repeated across ~6 sites (mitigated by a tiny `endpoints.DrainCustomEndpoints(service)` internal helper if desired — still no envelope extraction).
+
+### Option B — Full shared-envelope helper extraction
+
+Extract the duplicated `UseRouting → CORS → UseAuthorization → UseEndpoints` block into one helper taking a `mapModeEndpoints` delegate, then draining `MapEndpointActions`:
+
+```csharp
+service.UseModePipeline(mapModeEndpoints: endpoints => endpoints.MapMcp());
+```
+
+- **Pros**: removes the 6× envelope duplication; single place for CORS-probe logic.
+- **Cons**: to faithfully reproduce per-mode behavior the helper must re-grow parameters — Api-minimal's dev-Swagger pipeline + split mode assignment, gRPC's post-builder catch-all, the placeholder routes in Job/Default. The "shared" helper ends up parameterized back into per-mode variation, defeating the simplification. Higher blast radius across 4+ packages for a PR whose actual feature is the seam, not the refactor. **The plan's sketch under-models these asymmetries** — verified against real code, the clean single-delegate helper it implies does not hold.
+
+### Option C — Promote the extension `Configure(app)` workaround to documented API
+
+Keep the incidental ordering trick but document it.
+
+- **Cons**: routes stay **outside** the mode envelope (separate `UseRouting` pass), so CORS/authorization apply inconsistently — exactly the defect motivating the issue. Rejected.
+
+**Decision: Option A.** Record Option B as deferred.
+
+---
+
+## 4. Required decisions
+
+### 4.1 Decision 1 — Ordering
+
+**Custom routes are drained AFTER the mode maps its own endpoints (mode-endpoints-first).**
+
+Justification:
+
+- **Predictability.** The mode's contract (e.g. `/graphql`, `MapMcp`'s transport routes, `MapControllers`' attribute routes) is the service's primary surface and should win registration order.
+- **Route-conflict semantics.** ASP.NET Core endpoint routing resolves conflicts by route **precedence/specificity**, not registration order, so for *distinct* routes order is behaviorally irrelevant. Where it *does* matter is **gRPC's catch-all `MapGet("/")`**: that catch-all must remain the last fallback. Draining custom routes *before* the gRPC catch-all (i.e. mode-user-endpoints → custom → catch-all) keeps the catch-all as the genuine fallback. The recommended placement is "after the mode's *primary* mappings, before any mode-supplied catch-all/fallback."
+- **Least surprise on duplicate routes.** If a user maps a route that collides with a mode route, ASP.NET throws an `AmbiguousMatchException` at request time regardless of order — we do not silently shadow. This is acceptable and documented.
+
+Concretely for gRPC the drain goes between the user builder and the catch-all:
+
+```csharp
+app.UseEndpoints(endpoints =>
+{
+  endpointsBuilder(endpoints);                         // mode/user endpoints
+  foreach (var map in service.MapEndpointActions) map(endpoints);  // custom
+  endpoints.MapGet("/", () => "...gRPC client...");    // fallback stays last
+});
+```
+
+### 4.2 Decision 2 — Same routing + CORS + UseAuthorization envelope
+
+**Confirmed and intended: custom routes sit inside the same `UseRouting → (UseCors) → UseAuthorization → UseEndpoints` envelope as the mode endpoints.**
+
+Implications and the tradeoff, called out explicitly:
+
+- **Authorization applies.** Custom routes pass through `app.UseAuthorization()`. A custom endpoint that declares `.RequireAuthorization()` is enforced; one that does not is anonymous — identical to mode endpoints. This is **desirable**: it means an admin/control-plane route is secured by the same mechanism, not a side-channel.
+- **CORS applies *conditionally*.** `UseCors()` runs only when the CORS extension is present, using the default policy. So custom routes inherit the service's default CORS policy. This is the **right default** (consistency), but the tradeoff is that a custom webhook endpoint that should be CORS-exempt cannot opt out via this seam — it would need per-endpoint CORS metadata. We accept this; per-endpoint CORS override is **out of scope** for PR-3 (see [§9](#9-deferred--out-of-scope)).
+- **Single routing pass.** Because the drain is inside the mode's existing `UseEndpoints`, there is no second `UseRouting` and no middleware-ordering ambiguity — this is the concrete improvement over the `Configure(app)` workaround.
+
+### 4.3 Decision 3 — Behavior in non-application modes (`None` / `NotSet`, and Job)
+
+This decision is reshaped by the finding that **`None` already serves HTTP** (Job and `ConfigureDefaultServicePipeline` both set `None` and both have a live `UseEndpoints`).
+
+Chosen behavior:
+
+- **`MapEndpoints` is a pure recorder. It never throws and never inspects `PipelineMode`.** It only appends to `MapEndpointActions`. This keeps the **recording** order-independent: a user may call `MapEndpoints` before or after the mode-selecting call. Enforcement (for Job) is moved downstream to pipeline-build time precisely so that `MapEndpoints` itself can stay a simple, order-independent recorder (see the Job rule below).
+- **HTTP application modes (`Api`, `ApiControllers`, `GraphQL`, `Grpc`, `Mcp`) drain and serve custom routes** inside their envelope.
+- **Default `None` (`ConfigureDefaultServicePipeline`) drains and serves custom routes** — symmetric with the HTTP modes. `MapEndpoints` works on a bare service; custom routes are served alongside the 404 catch-all. **(Locked decision 2.)**
+- **Job (`ConfigureJob`) FORBIDS custom HTTP routes. (Locked decision 1.)** Product intent: worker services must not serve custom HTTP. The Job pipeline does **not** drain `MapEndpointActions`; instead it **throws** when custom routes have been recorded — see "Job enforcement mechanism" below.
+- **`NotSet` (no pipeline selected):** `RunAsync`/`StartAsync` already throw `ConfigurationException(Constants.Errors.PipelineNotSet)` when `PipelineMode == NotSet`. A `MapEndpoints` call with no mode selected records actions that are never drained, and the service fails to start for the **existing** reason (no pipeline). We do **not** add a second failure mode for `NotSet`. No new exception, no silent success.
+
+#### Job enforcement mechanism (Locked decision 1)
+
+The human chose **"Forbid on Job"**, overriding the prior "Allow" recommendation. This breaks the recorder's "always works on any mode" property *for Job specifically*: we deliberately replace it with a **deterministic startup-time failure**. The mechanism is specified precisely and honestly:
+
+- **Enforcement happens at Job pipeline-build/drain time, NOT at `MapEndpoints()` call time.** `MapEndpoints` is fluent and call-order-independent — a user may legitimately call `.MapEndpoints(...)` **before** `.ConfigureJob(...)`, at which point `PipelineMode` is still `NotSet`. Validating inside `MapEndpoints` would therefore be unreliable (it would miss the before-`ConfigureJob` ordering and could not distinguish Job from Default, both of which are `None`). So `MapEndpoints` stays a recorder, and the **Job pipeline-build delegate** performs the check once, after all fluent calls have run.
+
+- **Guard call-site:** inside the `ConfigurePipelineActions.Add(app => { ... })` delegate registered by `ConfigureJob` in `Hive.MicroServices.Job/IMicroServiceExtensions.cs` (currently lines 36–52). This delegate is replayed at pipeline-build time (`Host` build during `InitializeAsync`/`RunAsync`, and `ConfigureWebHost` in tests), which is **after** every fluent `MapEndpoints` call has recorded. The guard is the **first statement** of that delegate body — before `app.UseRouting()` — so the failure is raised before any HTTP envelope is constructed:
+
+  ```csharp
+  // Hive.MicroServices.Job/IMicroServiceExtensions.cs — inside the ConfigurePipelineActions delegate
+  .ConfigurePipelineActions.Add(app =>
+  {
+    if (service.MapEndpointActions.Count > 0)
+    {
+      throw new ConfigurationException(
+        "Hive.MicroServices.Job (worker) services cannot expose custom HTTP endpoints via MapEndpoints. " +
+        "Remove the MapEndpoints call, or select an HTTP pipeline mode (e.g. ConfigureApiPipeline / ConfigureGraphQLPipeline).");
+    }
+
+    app.UseRouting();
+    // ... existing CORS / UseAuthorization / UseEndpoints placeholder unchanged ...
+  });
+  ```
+
+- **Exception type and message.** Use **`ConfigurationException`** (from `Hive.Exceptions`, `hive.core/src/Hive.Abstractions/Exceptions/ConfigurationException.cs`) — consistent with how the codebase already signals misconfiguration (`Constants.Errors.PipelineNotSet` is thrown as `ConfigurationException` in `MicroService.RunAsync`/`StartAsync`). Message (exact):
+  > `Hive.MicroServices.Job (worker) services cannot expose custom HTTP endpoints via MapEndpoints. Remove the MapEndpoints call, or select an HTTP pipeline mode (e.g. ConfigureApiPipeline / ConfigureGraphQLPipeline).`
+
+  *(Not `InvalidOperationException`: `ConfigurationException` is the repo's established misconfiguration signal and is caught/logged by the same `RunAsync`/`StartAsync` try/catch as the pipeline-not-set case, giving consistent operator-facing behaviour.)*
+
+- **The guard keys off the Job pipeline-build path, NOT the `None` enum.** This is the crux of the Job-vs-Default asymmetry: both `ConfigureJob` and `ConfigureDefaultServicePipeline` set `PipelineMode.None`, so a mode-enum check could not tell them apart. Placing the throw **inside the `ConfigureJob` delegate specifically** (and draining inside the `ConfigureDefaultServicePipeline` delegate specifically) makes Job reject and Default serve, even though both report `None`. The discriminator is *which pipeline-build delegate ran*, i.e. Job intent — never `PipelineMode == None`.
+
+- **Honest tradeoff.** This sacrifices, for Job only, the call-order-independent **"always works"** guarantee that the recorder gives every other mode. In exchange, a Job service that wrongly calls `MapEndpoints` fails **deterministically at startup** with a clear, actionable message, rather than silently serving (the rejected "Allow") or silently dropping routes. The *recording* remains order-independent; only the *outcome* for Job is a startup error. Default-`None` retains the full "always works" guarantee.
+
+### 4.4 Decision 4 — Retirement of the `RegisterExtension` + `Configure(app)` workaround
+
+- **Nothing breaks.** The workaround relies on `MicroServiceExtension.Configure(app, this)` continuing to run, which it does — `ConfigureExtensions()` is unchanged. Existing services using the trick keep working.
+- **Deprecate by documentation, not by `[Obsolete]`.** `Configure(app)` is a legitimate extension hook for *middleware* (its real purpose); only its *abuse for endpoint mapping* is being superseded. We therefore do **not** mark anything `[Obsolete]` (that would wrongly flag valid middleware usage and trip `TreatWarningsAsErrors`). Instead:
+  - Document `MapEndpoints` as the supported way to add auxiliary routes (README + XML docs).
+  - Add a short note in the extension authoring docs: "to add HTTP routes to a moded service, use `MapEndpoints`, not `Configure(app)` + `UseEndpoints`."
+- **No migration required** for existing users; the workaround degrades to "still functional but discouraged."
+
+---
+
+## 5. Public API shape & null-guarding
+
+```csharp
+namespace Hive.MicroServices;   // core package — available to all modes
+
+public static class IMicroServiceMapEndpointsExtensions
+{
+  /// <summary>
+  /// Registers auxiliary HTTP routes that are served inside the selected pipeline
+  /// mode's routing/CORS/authorization envelope, alongside the mode's own endpoints.
+  /// Mode-agnostic and additive; does not affect <see cref="MicroServicePipelineMode"/>.
+  /// </summary>
+  public static IMicroService MapEndpoints(
+    this IMicroService microservice,
+    Action<IEndpointRouteBuilder> map)
+  {
+    _ = microservice ?? throw new ArgumentNullException(nameof(microservice));
+    _ = map ?? throw new ArgumentNullException(nameof(map));
+
+    var service = (MicroService)microservice;
+    service.MapEndpointActions.Add(map);
+    return microservice;
+  }
+}
+```
+
+- Lives in **core `Hive.MicroServices`** so a service can call it regardless of which mode package is referenced, and so the state lives next to `ConfigurePipelineActions`.
+- The `(MicroService)microservice` cast matches every other core extension (§2 finding 5).
+- Null-guards both arguments, consistent with `ConfigureMcpPipeline` / `ConfigureGrpcPipelineInternal`.
+- **`MapEndpoints` is a pure recorder and does NOT inspect `PipelineMode` or throw on Job.** The Job prohibition (Locked decision 1, §4.3) is enforced **downstream** in the Job pipeline-build delegate, not here — because `MapEndpoints` may be called before `ConfigureJob`, when the mode is still `NotSet`, and because Job and Default are indistinguishable by the `None` enum at this layer. Keeping `MapEndpoints` a recorder preserves call-order-independence of the recording; see §4.3 "Job enforcement mechanism".
+- `MapEndpointActions` declared on `MicroService` next to `ConfigurePipelineActions`:
+
+  ```csharp
+  // MicroService.cs, alongside line ~105
+  internal List<Action<IEndpointRouteBuilder>> MapEndpointActions { get; } = new();
+  ```
+
+---
+
+## 6. InternalsVisibleTo & testability
+
+`MicroService` already exposes internals to every mode package and both test/testing assemblies:
+
+```
+Hive.MicroServices.Api, .Grpc, .GraphQL, .Mcp, .Job, .Testing, .Tests
+```
+
+So:
+
+- Each mode's drain loop can read `service.MapEndpointActions` directly — **no new `InternalsVisibleTo` entries required.**
+- `Hive.MicroServices.Tests` can assert on `MapEndpointActions.Count` for a pure unit test of the recorder, and can exercise the full seam through `ConfigureWebHost` / `ConfigureTestHost` + `TestServer` for integration (the `ConfigureWebHost` helper at `Extensions/IMicroServiceExtensions.cs:82` already replays `ConfigurePipelineActions`, so drained routes are exercised end-to-end).
+
+---
+
+## 7. Test strategy for PR-3
+
+Mirror the existing `MicroServiceTests.CORS.Integration` TestServer pattern (`ConfigureTestHost()` → `Host.GetTestServer()` → `CreateClient()`).
+
+1. **Unit — recorder.** `[UnitTest]`: `new MicroService(...).MapEndpoints(e => ...)` and assert `((MicroService)svc).MapEndpointActions` has one entry; assert null-guards throw `ArgumentNullException`.
+
+2. **Integration — primary (MCP + custom route share DI).** `[IntegrationTest]` using `Hive.MicroServices.Testing`:
+   - `ConfigureMcpPipeline(...)` + `MapEndpoints(e => e.MapPost("/admin/flush", (MyState s) => ...))`.
+   - Register a **DI singleton** consumed by both the MCP tool and the `/admin/flush` handler; assert both observe the same instance (proves single envelope / shared service provider).
+   - Assert the MCP transport endpoint responds **and** `POST /admin/flush` responds `200`.
+
+3. **Integration — cross-mode spot check (GraphQL).** `[IntegrationTest]`: `ConfigureGraphQLPipeline(...)` + `MapEndpoints(e => e.MapGet("/admin/ping", () => Results.Ok()))`; assert `/graphql` and `/admin/ping` both respond. Confirms the seam is genuinely mode-agnostic, not MCP-specific.
+
+4. **Ordering / fallback guard (gRPC).** `[IntegrationTest]`: custom `MapGet("/healthz-custom")` on a gRPC service; assert it resolves and the gRPC catch-all `/` still returns its guidance string (custom drain precedes the catch-all).
+
+5. **Job rejection — startup failure (Locked decision 1).** `[IntegrationTest]` (or `[UnitTest]` driving startup): `new MicroService(...).ConfigureJob().MapEndpoints(e => e.MapGet("/admin/ping", () => Results.Ok()))`, then attempt to start the pipeline (`RunAsync` with a short-cancel, or `ConfigureWebHost` + build). Assert a **`ConfigurationException`** is thrown at pipeline build, with message containing `"Job (worker) services cannot expose custom HTTP endpoints via MapEndpoints"`.
+   - **Also assert order-independence of the throw:** a second case calling `.MapEndpoints(...)` **before** `.ConfigureJob()` must throw the *same* exception — proving the guard is at build time, not `MapEndpoints` call time, and is unaffected by call order.
+   - Pair with a negative case: `ConfigureJob()` with **no** `MapEndpoints` call starts normally and serves the placeholder `/` (no regression).
+
+6. **Default `None` serves custom routes (Locked decision 2).** `[IntegrationTest]`: `ConfigureDefaultServicePipeline()` + `MapEndpoints(e => e.MapGet("/admin/ping", () => Results.Ok()))`; assert `GET /admin/ping` responds `200` and an unmapped path still returns the `404` catch-all. Confirms Default-`None` drains while Job-`None` throws — the asymmetry keys off the pipeline path, not the enum.
+
+7. *(Optional)* **Auth envelope check.** Custom route with `.RequireAuthorization()` returns `401` unauthenticated, proving it sits inside `UseAuthorization`.
+
+Use `[UnitTest]` / `[IntegrationTest]` trait attributes and `CloudTek.Testing` + `Hive.MicroServices.Testing` per repo conventions.
+
+---
+
+## 8. Implementation task breakdown (PR-3, file by file)
+
+1. **`Hive.MicroServices/MicroService.cs`** — add `internal List<Action<IEndpointRouteBuilder>> MapEndpointActions { get; } = new();` next to `ConfigurePipelineActions` (~line 105). Add `using Microsoft.AspNetCore.Routing;` if not present.
+2. **`Hive.MicroServices/` (new file, e.g. `IMicroServiceMapEndpointsExtensions.cs`)** — public `MapEndpoints` extension with null-guards (see §5).
+3. **`Hive.MicroServices.Api/IMicroServiceExtensions.cs`** — in `ConfigureApiPipelineInternal`'s `UseEndpoints`, after `endpointBuilder(endpoints)` (note: minimal passes the user delegate; controllers pass `MapControllers`), drain `service.MapEndpointActions`. Covers both `Api` and `ApiControllers`.
+4. **`Hive.MicroServices.GraphQL/IMicroServiceExtensions.cs`** — drain after `MapGraphQL("/graphql")`.
+5. **`Hive.MicroServices.Grpc/IMicroServiceExtensions.cs`** — drain after `endpointsBuilder(endpoints)` and **before** the catch-all `MapGet("/")`.
+6. **`Hive.MicroServices.Mcp/IMicroServiceExtensions.cs`** — drain after `MapMcp()`.
+7. **`Hive.MicroServices.Job/IMicroServiceExtensions.cs` — DOES NOT drain; GUARDS instead (Locked decision 1).** Inside the `ConfigurePipelineActions.Add(app => { ... })` delegate (currently lines 36–52), add as the **first statement** (before `app.UseRouting()`): if `service.MapEndpointActions.Count > 0`, `throw new ConfigurationException("Hive.MicroServices.Job (worker) services cannot expose custom HTTP endpoints via MapEndpoints. Remove the MapEndpoints call, or select an HTTP pipeline mode (e.g. ConfigureApiPipeline / ConfigureGraphQLPipeline).");`. Add `using Hive.Exceptions;` if not present. Do **not** add a drain loop to Job, and do **not** call the optional `DrainCustomEndpoints` helper here. The placeholder `MapGet("/")` is unchanged. See §4.3 "Job enforcement mechanism".
+8. **`Hive.MicroServices/Extensions/IMicroServiceExtensions.cs` `ConfigureDefaultServicePipeline` — DRAINS (Locked decision 2).** In its `UseEndpoints` body, drain `service.MapEndpointActions` **before** the `MapGet("/*")` 404 catch-all (so custom routes take precedence over the fallback, mirroring the gRPC ordering rule in §4.1). This makes `MapEndpoints` work on a bare `None` service. Note: this is the **Default** `None` path only — it intentionally diverges from the Job `None` path (task 7), and the divergence is expressed by *which delegate* drains vs. throws, not by a `PipelineMode` check.
+9. *(Optional helper)* a tiny `internal static void DrainCustomEndpoints(this IEndpointRouteBuilder endpoints, MicroService service)` in core to avoid repeating the loop — keeps each draining site to one line. No envelope extraction. **Used by the draining sites only (Api, GraphQL, gRPC, MCP, Default); Job does not call it** (Job guards, it does not drain).
+10. **Tests** — `Hive.MicroServices.Tests`: add the unit + integration files from §7, including the **Job-rejection startup-failure test** (asserting `ConfigurationException` with the expected message, in both call orders) and the **Default-`None`-serves-custom-routes test**.
+11. **Docs** — README note for `MapEndpoints`; extension-authoring note discouraging `Configure(app)` for endpoint mapping (§4.4). Link this ADR.
+12. **Build/verify** — `dotnet tool run cloudtek-build --target All --skip RunChecks` (then full `All` for the format/analyzer gate; repo runs `TreatWarningsAsErrors` with 2-space indent / file-scoped namespaces / no trailing newline in `.cs`).
+
+**Do not** touch `Version.targets` in PR-3 unless the milestone process bumps it separately; the feature targets 10.2.0 but the version bump is a release concern, not this PR's.
+
+---
+
+## 9. Deferred / out of scope
+
+- **Full shared-envelope helper extraction (Option B).** Deferred; revisit only if a 7th mode lands or the envelope duplication becomes a maintenance burden. The per-mode asymmetries (§2) make the abstraction premature (YAGNI).
+- **Per-endpoint CORS opt-out / per-route CORS policy selection** for custom routes (§4.2). Out of scope; custom routes inherit the default policy.
+- **A dedicated `Job` enum value** distinct from `None` (§4.3). The `None`-means-two-things ambiguity predates this work and is not introduced by it. **Locked decision 1 now makes this ambiguity load-bearing:** because Job and Default both resolve to `PipelineMode.None`, the Job-forbids / Default-serves split *cannot* be expressed by a mode-enum check and must instead live in the respective pipeline-build delegates (§4.3). A future dedicated `Job` enum value (or a `bool ForbidsCustomEndpoints` flag on `MicroService`) would let the guard be centralised; deferred as a larger change. **Flagged as a NEW consequence of decision 1** — see §11.
+- **`MapEndpoints` overloads** (e.g. accepting an `IServiceProvider` or a named-group prefix). YAGNI; ship the single `Action<IEndpointRouteBuilder>` form.
+
+---
+
+## 10. Resolved decisions
+
+Both questions previously open here have been decided by the human. They are now locked into the design above.
+
+1. **Job HTTP exposure (§4.3) — RESOLVED: FORBID on Job.** The human overrode the prior "allow" recommendation. Worker/Job services MUST NOT expose custom HTTP routes via `MapEndpoints`. Enforcement is a **deterministic startup-time failure**, not a `MapEndpoints`-call-time check: the **Job pipeline-build delegate** in `Hive.MicroServices.Job/IMicroServiceExtensions.cs` throws `ConfigurationException` (message in §4.3) as its first statement when `MapEndpointActions` is non-empty. `MapEndpoints` itself stays a pure recorder. This trades the recorder's call-order-independent "always works" guarantee — **for Job only** — for a clear startup error. Captured in: TL;DR, §4.3 (Decision 3 + "Job enforcement mechanism"), §5, §7 (test 5), §8 (task 7, 9, 10).
+
+2. **Default `None` pipeline drain (§8) — RESOLVED: DRAIN.** A bare `ConfigureDefaultServicePipeline` service drains `MapEndpointActions` and serves custom routes (before its 404 catch-all), symmetric with the HTTP modes. Captured in: TL;DR, §4.3 (Decision 3), §8 (task 8), §7 (test 6).
+
+**Job-vs-Default `None` reconciliation (explicit).** Both `ConfigureJob` and `ConfigureDefaultServicePipeline` set `PipelineMode.None`. The forbid/serve split therefore **cannot** key off the enum. It keys off **which pipeline-build delegate runs**: the `ConfigureJob` delegate throws; the `ConfigureDefaultServicePipeline` delegate drains. The discriminator is **Job intent at the build site**, never `PipelineMode == None`. Any future reader changing this must preserve that: do not "simplify" the guard into a `PipelineMode.None` check — it would wrongly reject bare Default services too.
+
+Everything else is determined by the existing code and recorded above.
+
+---
+
+## 11. New issues raised by the locked decisions
+
+- **The `None`-means-two-things ambiguity is now load-bearing (not merely cosmetic).** Before decision 1, `Job == Default == None` was a harmless naming wart. Now the forbid/serve behaviour split rides entirely on the two pipeline-build delegates being distinct; there is no enum-level guard rail. **Risk:** a future refactor that consolidates the Job and Default pipeline-build closures, or that reroutes Job through `ConfigureDefaultServicePipeline`, would silently re-enable custom HTTP on Job (or break Default). **Mitigations already in this design:** (a) the §7 test 5 asserts Job throws in *both* call orders, which fails loudly if the guard is lost; (b) the §4.3 / §10 notes forbid collapsing the guard into a `PipelineMode.None` check. **Recommended follow-up (deferred, §9):** introduce a dedicated `Job` enum value or a `MicroService.ForbidsCustomEndpoints` flag so the guard has a single, enum-anchored home. Not in scope for PR-3; flagged for the milestone owner.
+
+- **No interaction problem found between the Job guard and the rest of the seam.** The guard runs before `app.UseRouting()` in the Job delegate, so it cannot interfere with CORS/auth/endpoint wiring; it shares no state with the draining sites; and because `MapEndpoints` remains a recorder, the gRPC catch-all ordering (§4.1), conditional CORS (§4.2), and the `NotSet` pipeline-not-set guard are all unaffected. The only behavioural change for non-Job modes is the new Default-`None` drain (decision 2), which is additive.
+
+---
+
+## Related documentation
+
+- [cors_extraction_analysis.md](cors_extraction_analysis.md) — CORS placement / `UseCors()` conditional middleware
+- [otel_configuration_strategy.md](otel_configuration_strategy.md) — house-style precedent for Options + recommendation + plan
+- [../../.claude/rules/architecture.md](../../.claude/rules/architecture.md) — pipeline modes, extension pattern, interface hierarchy
+- `hive.microservices/src/Hive.MicroServices.Mcp/IMicroServiceExtensions.cs` — canonical envelope to mirror the drain into

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,118 @@
+# Getting Started — Build Your First Hive Service
+
+This guide walks through the minimum steps to get a Hive microservice running.
+For a broader overview of the framework, see the [root README](../README.md).
+
+---
+
+## Prerequisites
+
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)
+- Optional: `CloudTek.Build.Tool` for full builds (see [build.md](build.md))
+
+---
+
+## 1. Create a new project
+
+```bash
+dotnet new web -n MyHiveService
+cd MyHiveService
+```
+
+> Note: The repository does not currently publish `dotnet new` hive-* templates.
+> Use `dotnet new web` (or `dotnet new worker` for background jobs) as the starting point.
+
+---
+
+## 2. Add NuGet references
+
+For a REST API service:
+
+```bash
+dotnet add package Hive.MicroServices
+dotnet add package Hive.MicroServices.Api
+dotnet add package Hive.OpenTelemetry   # optional but recommended
+```
+
+For a background worker:
+
+```bash
+dotnet add package Hive.MicroServices
+dotnet add package Hive.MicroServices.Job
+```
+
+---
+
+## 3. Write your service
+
+Replace the generated `Program.cs`:
+
+```csharp
+using Hive;
+using Hive.MicroServices.Api;
+using Hive.OpenTelemetry;
+
+var service = new MicroService("my-first-service")
+    .WithOpenTelemetry()
+    .ConfigureApiPipeline(endpoints =>
+    {
+        endpoints.MapGet("/", () => "Hello from Hive!");
+    });
+
+await service.RunAsync();
+```
+
+---
+
+## 4. Run it
+
+```bash
+dotnet run
+```
+
+Hive automatically registers Kubernetes-compatible health probes at:
+
+- `GET /startup` — startup probe
+- `GET /readiness` — readiness probe
+- `GET /liveness` — liveness probe
+
+---
+
+## 5. Add configuration and services
+
+```csharp
+var config = new ConfigurationBuilder()
+    .AddJsonFile("appsettings.json", optional: true)
+    .AddEnvironmentVariables()
+    .Build();
+
+var service = new MicroService("my-service")
+    .WithOpenTelemetry()
+    .ConfigureServices((services, configuration) =>
+    {
+        services.AddSingleton<IGreetingService, GreetingService>();
+    })
+    .ConfigureApiPipeline(endpoints =>
+    {
+        endpoints.MapGet("/greet", (IGreetingService greeter) =>
+            Results.Ok(greeter.Greet()));
+    });
+
+await service.RunAsync(config);
+```
+
+---
+
+## Next steps
+
+| Topic | Link |
+|---|---|
+| Pipeline modes (GraphQL, gRPC, MCP, Job) | [hive.microservices README](../hive.microservices/README.md) |
+| Core framework constraints & gotchas | [Hive.MicroServices README](../hive.microservices/src/Hive.MicroServices/README.md) |
+| MCP server hosting | [Hive.MicroServices.Mcp README](../hive.microservices/src/Hive.MicroServices.Mcp/README.md) |
+| OpenTelemetry configuration | [Hive.OpenTelemetry README](../hive.opentelemetry/README.md) |
+| Writing integration tests | [Hive.MicroServices.Testing README](../hive.microservices/src/Hive.MicroServices.Testing/README.md) |
+| CORS configuration | [CORS README](../hive.microservices/src/Hive.MicroServices/CORS/README.md) |
+| Messaging (Wolverine / RabbitMQ) | [Hive.Messaging README](../hive.extensions/src/Hive.Messaging/README.md) |
+| Azure Functions | [Hive.Functions README](../hive.functions/README.md) |
+| Full documentation index | [docs/README.md](README.md) |

--- a/hive.core/src/Hive.Abstractions/Constants.Errors.cs
+++ b/hive.core/src/Hive.Abstractions/Constants.Errors.cs
@@ -13,6 +13,13 @@ namespace Hive
       public const string PipelineNotSet = "No pipeline has been configured. Aborting";
 
       /// <summary>
+      /// The error message thrown when a Job (worker) service has <c>MapEndpoints</c> calls recorded at pipeline-build time.
+      /// </summary>
+      public const string MapEndpointsJobForbidden =
+        "Hive.MicroServices.Job (worker) services cannot expose custom HTTP endpoints via MapEndpoints. " +
+        "Remove the MapEndpoints call, or select an HTTP pipeline mode (e.g. ConfigureApiPipeline / ConfigureGraphQLPipeline).";
+
+      /// <summary>
       /// The error message format when ASPNETCORE_ENVIRONMENT and DOTNET_ENVIRONMENT are both set to conflicting values.
       /// {0} = ASPNETCORE_ENVIRONMENT value, {1} = DOTNET_ENVIRONMENT value.
       /// </summary>

--- a/hive.microservices/README.md
+++ b/hive.microservices/README.md
@@ -573,3 +573,9 @@ All packages are published to NuGet:
 ## Contributing
 
 This is part of the Hive monorepo. For contribution guidelines, see the [main repository](https://github.com/cloud-tek/hive).
+
+## See also
+
+- [Full documentation index](../docs/README.md) — design docs, topic guides, build reference, and all package READMEs
+- [Getting started guide](../docs/getting-started.md) — step-by-step first service walkthrough
+- [Build & CI reference](../docs/build.md) — `cloudtek-build` targets and `dotnet` CLI equivalents

--- a/hive.microservices/demo/Hive.MicroServices.Demo.Mcp/Program.cs
+++ b/hive.microservices/demo/Hive.MicroServices.Demo.Mcp/Program.cs
@@ -14,6 +14,13 @@ var service = new MicroService("hive-microservices-mcp-demo")
     .ConfigureMcpPipeline(mcp =>
     {
       mcp.WithTools<WeatherForecastTool>();
+    })
+    .MapEndpoints(routes =>
+    {
+      // Custom admin endpoint sharing the same DI singleton as WeatherForecastTool.
+      // Demonstrates that MapEndpoints routes run inside the same routing/auth envelope.
+      routes.MapGet("/admin/forecast/summary", (IWeatherForecastService svc) =>
+        Results.Ok(new { count = svc.GetWeatherForecast().Count() }));
     });
 
 await service.RunAsync();

--- a/hive.microservices/src/Hive.MicroServices.Api/IMicroServiceExtensions.cs
+++ b/hive.microservices/src/Hive.MicroServices.Api/IMicroServiceExtensions.cs
@@ -17,6 +17,14 @@ namespace Hive.MicroServices.Api
     /// <param name="microservice"></param>
     /// <param name="action"></param>
     /// <returns><see cref="IMicroService"/></returns>
+    /// <remarks>
+    /// Sets <see cref="MicroServicePipelineMode.Api"/> on the service. Pipeline mode is set once;
+    /// calling a second <c>Configure*Pipeline</c> method on the same instance throws
+    /// <see cref="InvalidOperationException"/> with message <c>"MicroService PipelineMode is already set"</c>.
+    /// Auxiliary HTTP routes (control-plane endpoints, webhooks, admin actions) can be added alongside
+    /// the primary routes via <c>MapEndpoints(...)</c>, and they share this mode's routing, CORS, and
+    /// authorization envelope.
+    /// </remarks>
     public static IMicroService ConfigureApiPipeline(this IMicroService microservice, Action<Microsoft.AspNetCore.Routing.IEndpointRouteBuilder> action)
     {
       var service = (MicroService)microservice;
@@ -33,6 +41,14 @@ namespace Hive.MicroServices.Api
     /// </summary>
     /// <param name="microservice"></param>
     /// <returns><see cref="IMicroService"/></returns>
+    /// <remarks>
+    /// Sets <see cref="MicroServicePipelineMode.ApiControllers"/> on the service. Pipeline mode is set once;
+    /// calling a second <c>Configure*Pipeline</c> method on the same instance throws
+    /// <see cref="InvalidOperationException"/> with message <c>"MicroService PipelineMode is already set"</c>.
+    /// Auxiliary HTTP routes (control-plane endpoints, webhooks, admin actions) can be added alongside
+    /// the controller routes via <c>MapEndpoints(...)</c>, and they share this mode's routing, CORS, and
+    /// authorization envelope.
+    /// </remarks>
     public static IMicroService ConfigureApiControllerPipeline(this IMicroService microservice)
     {
       var service = (MicroService)microservice;

--- a/hive.microservices/src/Hive.MicroServices.Api/IMicroServiceExtensions.cs
+++ b/hive.microservices/src/Hive.MicroServices.Api/IMicroServiceExtensions.cs
@@ -85,7 +85,11 @@ namespace Hive.MicroServices.Api
             }
 
             app.UseAuthorization();
-            app.UseEndpoints(endpointBuilder);
+            app.UseEndpoints(endpoints =>
+            {
+              endpointBuilder(endpoints);
+              endpoints.DrainCustomEndpoints(service);
+            });
           });
 
       return microservice;

--- a/hive.microservices/src/Hive.MicroServices.GraphQL/IMicroServiceExtensions.cs
+++ b/hive.microservices/src/Hive.MicroServices.GraphQL/IMicroServiceExtensions.cs
@@ -17,6 +17,14 @@ public static class IMicroServiceExtensions
   /// <param name="microservice"></param>
   /// <param name="schemaBuilder"></param>
   /// <returns><see cref="IMicroService"/></returns>
+  /// <remarks>
+  /// Sets <see cref="MicroServicePipelineMode.GraphQL"/> on the service. Pipeline mode is set once;
+  /// calling a second <c>Configure*Pipeline</c> method on the same instance throws
+  /// <see cref="InvalidOperationException"/> with message <c>"MicroService PipelineMode is already set"</c>.
+  /// Auxiliary HTTP routes (control-plane endpoints, webhooks, admin actions) can be added alongside
+  /// the GraphQL endpoint via <c>MapEndpoints(...)</c>, and they share this mode's routing, CORS, and
+  /// authorization envelope.
+  /// </remarks>
   public static IMicroService ConfigureGraphQLPipeline(this IMicroService microservice, Action<IRequestExecutorBuilder> schemaBuilder)
   {
     var service = (MicroService)microservice;

--- a/hive.microservices/src/Hive.MicroServices.GraphQL/IMicroServiceExtensions.cs
+++ b/hive.microservices/src/Hive.MicroServices.GraphQL/IMicroServiceExtensions.cs
@@ -59,6 +59,7 @@ public static class IMicroServiceExtensions
       app.UseEndpoints(endpoints =>
         {
           endpoints.MapGraphQL("/graphql");
+          endpoints.DrainCustomEndpoints(service);
         });
     });
 

--- a/hive.microservices/src/Hive.MicroServices.Grpc/IMicroServiceExtensions.cs
+++ b/hive.microservices/src/Hive.MicroServices.Grpc/IMicroServiceExtensions.cs
@@ -69,6 +69,7 @@ namespace Hive.MicroServices.Grpc
             app.UseEndpoints(endpoints =>
               {
                 endpointsBuilder(endpoints);
+                endpoints.DrainCustomEndpoints(service);
                 endpoints.MapGet("/", () => "Communication with gRPC endpoints must be made through a gRPC client. To learn how to create a client, visit: https://go.microsoft.com/fwlink/?linkid=2086909");
               });
           });

--- a/hive.microservices/src/Hive.MicroServices.Grpc/IMicroServiceExtensions.cs
+++ b/hive.microservices/src/Hive.MicroServices.Grpc/IMicroServiceExtensions.cs
@@ -17,6 +17,14 @@ namespace Hive.MicroServices.Grpc
     /// <param name="microservice"></param>
     /// <param name="endpointsBuilder"></param>
     /// <returns><see cref="IMicroService"/></returns>
+    /// <remarks>
+    /// Sets <see cref="MicroServicePipelineMode.Grpc"/> on the service. Pipeline mode is set once;
+    /// calling a second <c>Configure*Pipeline</c> method on the same instance throws
+    /// <see cref="InvalidOperationException"/> with message <c>"MicroService PipelineMode is already set"</c>.
+    /// Auxiliary HTTP routes (control-plane endpoints, webhooks, admin actions) can be added alongside
+    /// the gRPC services via <c>MapEndpoints(...)</c>; they share this mode's routing, CORS, and
+    /// authorization envelope, and are registered before the mode's catch-all fallback route.
+    /// </remarks>
     public static IMicroService ConfigureGrpcPipeline(this IMicroService microservice, Action<IEndpointRouteBuilder> endpointsBuilder)
     {
       return microservice.ConfigureGrpcPipelineInternal(endpointsBuilder, configureGrpc: (services) => services.AddGrpc());
@@ -28,6 +36,14 @@ namespace Hive.MicroServices.Grpc
     /// <param name="microservice"></param>
     /// <param name="endpointsBuilder"></param>
     /// <returns><see cref="IMicroService"/></returns>
+    /// <remarks>
+    /// Sets <see cref="MicroServicePipelineMode.Grpc"/> on the service using the protobuf-net code-first
+    /// gRPC variant. Pipeline mode is set once; calling a second <c>Configure*Pipeline</c> method on the
+    /// same instance throws <see cref="InvalidOperationException"/> with message
+    /// <c>"MicroService PipelineMode is already set"</c>. Auxiliary HTTP routes can be added alongside
+    /// the gRPC services via <c>MapEndpoints(...)</c>, sharing this mode's routing, CORS, and
+    /// authorization envelope.
+    /// </remarks>
     public static IMicroService ConfigureCodeFirstGrpcPipeline(this IMicroService microservice, Action<IEndpointRouteBuilder> endpointsBuilder)
     {
       return microservice.ConfigureGrpcPipelineInternal(endpointsBuilder, configureGrpc: (services) => services.AddCodeFirstGrpc());

--- a/hive.microservices/src/Hive.MicroServices.Job/IMicroServiceExtensions.cs
+++ b/hive.microservices/src/Hive.MicroServices.Job/IMicroServiceExtensions.cs
@@ -18,6 +18,16 @@ namespace Hive.MicroServices.Job
     /// <param name="microservice"></param>
     /// <returns><see cref="IMicroService"/></returns>
     /// <exception cref="ArgumentNullException">Thrown when any of the provided arguments are null</exception>
+    /// <remarks>
+    /// Sets <see cref="MicroServicePipelineMode.None"/> on the service (worker/job intent). Pipeline mode
+    /// is set once; calling a second <c>Configure*Pipeline</c> method on the same instance throws
+    /// <see cref="InvalidOperationException"/> with message <c>"MicroService PipelineMode is already set"</c>.
+    /// Job (worker) services cannot serve custom HTTP routes: if <c>MapEndpoints(...)</c> has been called on
+    /// the service, the pipeline throws <see cref="Hive.Exceptions.ConfigurationException"/> at startup with
+    /// message <c>"Hive.MicroServices.Job (worker) services cannot expose custom HTTP endpoints via MapEndpoints.
+    /// Remove the MapEndpoints call, or select an HTTP pipeline mode (e.g. ConfigureApiPipeline /
+    /// ConfigureGraphQLPipeline)."</c>
+    /// </remarks>
     public static IMicroService ConfigureJob(this IMicroService microservice)
     {
       _ = microservice ?? throw new ArgumentNullException(nameof(microservice));

--- a/hive.microservices/src/Hive.MicroServices.Job/IMicroServiceExtensions.cs
+++ b/hive.microservices/src/Hive.MicroServices.Job/IMicroServiceExtensions.cs
@@ -1,3 +1,4 @@
+using Hive.Exceptions;
 using Hive.MicroServices.Extensions;
 using Hive.MicroServices.Job.Services;
 using Microsoft.AspNetCore.Builder;
@@ -35,6 +36,11 @@ namespace Hive.MicroServices.Job
           .ConfigureExtensions()
           .ConfigurePipelineActions.Add(app =>
           {
+            if (service.MapEndpointActions.Count > 0)
+            {
+              throw new ConfigurationException(Constants.Errors.MapEndpointsJobForbidden);
+            }
+
             app.UseRouting();
 
             // Apply CORS middleware (uses default policy configured in Extension)

--- a/hive.microservices/src/Hive.MicroServices.Mcp/IMicroServiceExtensions.cs
+++ b/hive.microservices/src/Hive.MicroServices.Mcp/IMicroServiceExtensions.cs
@@ -52,6 +52,7 @@ public static class IMicroServiceExtensions
       app.UseEndpoints(endpoints =>
         {
           endpoints.MapMcp();
+          endpoints.DrainCustomEndpoints(service);
         });
     });
 

--- a/hive.microservices/src/Hive.MicroServices.Mcp/IMicroServiceExtensions.cs
+++ b/hive.microservices/src/Hive.MicroServices.Mcp/IMicroServiceExtensions.cs
@@ -15,6 +15,14 @@ public static class IMicroServiceExtensions
   /// <param name="microservice">The microservice to configure</param>
   /// <param name="serverBuilder">Callback used to register tools, prompts and resources on the MCP server</param>
   /// <returns><see cref="IMicroService"/></returns>
+  /// <remarks>
+  /// Sets <see cref="MicroServicePipelineMode.Mcp"/> on the service. Pipeline mode is set once;
+  /// calling a second <c>Configure*Pipeline</c> method on the same instance throws
+  /// <see cref="InvalidOperationException"/> with message <c>"MicroService PipelineMode is already set"</c>.
+  /// Auxiliary HTTP routes (control-plane endpoints, webhooks, admin actions) can be added alongside
+  /// the MCP transport via <c>MapEndpoints(...)</c>, and they share this mode's routing, CORS, and
+  /// authorization envelope.
+  /// </remarks>
   public static IMicroService ConfigureMcpPipeline(this IMicroService microservice, Action<IMcpServerBuilder> serverBuilder)
   {
     _ = microservice ?? throw new ArgumentNullException(nameof(microservice));

--- a/hive.microservices/src/Hive.MicroServices.Mcp/README.md
+++ b/hive.microservices/src/Hive.MicroServices.Mcp/README.md
@@ -1,0 +1,209 @@
+# Hive.MicroServices.Mcp
+
+Model Context Protocol (MCP) server support for Hive microservices, exposing AI-callable tools, prompts, and resources over the streamable HTTP transport via `ModelContextProtocol.AspNetCore`.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Quick Start](#quick-start)
+- [Tool Registration](#tool-registration)
+- [Transport](#transport)
+- [Coexistence with Custom Routes](#coexistence-with-custom-routes)
+- [Prompts and Resources](#prompts-and-resources)
+
+## Overview
+
+`Hive.MicroServices.Mcp` activates the `Mcp` pipeline mode on a `MicroService`. The pipeline wires a standard ASP.NET Core middleware stack — routing, optional CORS, authorization — and maps the MCP streamable HTTP endpoint via `MapMcp()`. The result is a fully hosted MCP server that participates in Hive's Kubernetes probes, OpenTelemetry integration, and extension ecosystem.
+
+Use this package when you want to expose AI-callable capabilities (tools, prompts, resources) to LLM clients such as Claude, Copilot, or any MCP-compatible host, while keeping the service inside the same Hive operational envelope as your REST or gRPC services.
+
+**When to use:**
+- You are building a standalone MCP server or a sidecar that surfaces domain operations to AI agents.
+- You need tools to resolve shared application services from DI (e.g. a repository, a cache, an HTTP client).
+- You want auxiliary HTTP routes (admin, webhooks) alongside the MCP endpoint without a separate service.
+
+**Not compatible with:**
+- `Hive.MicroServices.Job` — worker services have no HTTP pipeline; `MapEndpoints` on a Job host throws `ConfigurationException` at startup.
+
+## Quick Start
+
+```csharp
+using Hive.MicroServices;
+using Hive.MicroServices.Mcp;
+using Hive.OpenTelemetry;
+
+var service = new MicroService("my-mcp-server")
+    .WithOpenTelemetry()
+    .ConfigureServices((services, configuration) =>
+    {
+      services.AddSingleton<IWeatherForecastService, WeatherForecastService>();
+    })
+    .ConfigureMcpPipeline(mcp =>
+    {
+      mcp.WithTools<WeatherForecastTool>();
+    });
+
+await service.RunAsync();
+```
+
+`ConfigureMcpPipeline` accepts an `Action<IMcpServerBuilder>` callback. Everything registered on the builder (tools, prompts, resources) is served over the MCP streamable HTTP endpoint.
+
+## Tool Registration
+
+Tools are plain C# classes decorated with `[McpServerToolType]`. Individual methods are decorated with `[McpServerTool]`. Parameters that are not MCP arguments are resolved from DI — the MCP SDK performs constructor and parameter injection automatically.
+
+### Attribute-based tool
+
+```csharp
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+
+[McpServerToolType]
+public class WeatherForecastTool
+{
+  [McpServerTool(Name = "get_weather_forecast")]
+  [Description("Gets the weather forecast for the next few days.")]
+  public static IEnumerable<WeatherForecast> GetWeatherForecast(IWeatherForecastService service)
+  {
+    return service.GetWeatherForecast();
+  }
+}
+```
+
+`IWeatherForecastService` is injected by the MCP runtime from the DI container. No constructor is needed — the parameter is resolved per-invocation.
+
+### Registration
+
+```csharp
+.ConfigureMcpPipeline(mcp =>
+{
+  mcp.WithTools<WeatherForecastTool>();
+})
+```
+
+Register one tool type per `WithTools<T>()` call, or chain multiple calls:
+
+```csharp
+.ConfigureMcpPipeline(mcp =>
+{
+  mcp
+    .WithTools<WeatherForecastTool>()
+    .WithTools<InventoryTool>();
+})
+```
+
+The `[McpServerTool]` attribute's `Name` property sets the tool name visible to MCP clients. `[Description]` on both the class and its methods populates the MCP schema descriptions shown to LLMs.
+
+## Transport
+
+The MCP server uses the **streamable HTTP transport** (`WithHttpTransport()`). The endpoint is registered at the default path `/mcp` (the `ModelContextProtocol.AspNetCore` default) via `MapMcp()` inside `UseEndpoints`.
+
+**Middleware order applied by `ConfigureMcpPipeline`:**
+
+```
+UseRouting
+  └─ UseCors          (only when a CORS extension is registered)
+       └─ UseAuthorization
+            └─ UseEndpoints
+                 ├─ MapMcp()              ← MCP streamable HTTP endpoint
+                 └─ [custom MapEndpoints routes]
+```
+
+No additional transport configuration is required. MCP clients connect to `POST /mcp` (SSE stream) on the service's configured port.
+
+## Coexistence with Custom Routes
+
+Use the `MapEndpoints` seam to register auxiliary HTTP routes that run **inside the same routing/CORS/authorization envelope** as the MCP endpoint, sharing the same DI container. This is the recommended approach; it replaces older workarounds using `RegisterExtension` with a manual `Configure(IApplicationBuilder)` override.
+
+The seam is defined in `Hive.MicroServices` and is mode-agnostic. See the design rationale in [`docs/design/custom_endpoints_seam_design.md`](../../../../docs/design/custom_endpoints_seam_design.md).
+
+### Example — admin route sharing a DI singleton with a tool
+
+```csharp
+var service = new MicroService("hive-microservices-mcp-demo")
+    .WithOpenTelemetry()
+    .ConfigureServices((services, configuration) =>
+    {
+      // Singleton shared by both the MCP tool and the admin route.
+      services.AddSingleton<IWeatherForecastService, WeatherForecastService>();
+    })
+    .ConfigureMcpPipeline(mcp =>
+    {
+      mcp.WithTools<WeatherForecastTool>();
+    })
+    .MapEndpoints(routes =>
+    {
+      // Custom admin endpoint — resolves the same IWeatherForecastService singleton.
+      routes.MapGet("/admin/forecast/summary", (IWeatherForecastService svc) =>
+        Results.Ok(new { count = svc.GetWeatherForecast().Count() }));
+    });
+
+await service.RunAsync();
+```
+
+`MapEndpoints` can be called before or after `ConfigureMcpPipeline` — order does not matter. Multiple `MapEndpoints` calls accumulate; all registered delegates run inside the single `UseEndpoints` block.
+
+**Job host restriction:** calling `MapEndpoints` on a service that uses `ConfigureJobPipeline` throws `ConfigurationException` at startup with the message from `Constants.Errors.MapEndpointsJobForbidden`. This is by design — Job (worker) services have no HTTP pipeline.
+
+## Prompts and Resources
+
+`ModelContextProtocol` 1.4.0 supports MCP prompts and resources via attribute-based registration, symmetric with tools.
+
+### Prompts
+
+Decorate a class with `[McpServerPromptType]` and methods with `[McpServerPrompt]`, then register with `WithPrompts<T>()`:
+
+```csharp
+using ModelContextProtocol.Server;
+
+[McpServerPromptType]
+public class ForecastPrompts
+{
+  [McpServerPrompt(Name = "summarize_forecast")]
+  [Description("Returns a prompt that asks the LLM to summarize the current weather forecast.")]
+  public static string SummarizeForecast(IWeatherForecastService svc)
+  {
+    var items = svc.GetWeatherForecast();
+    return $"Summarize this forecast in one sentence: {string.Join(", ", items)}";
+  }
+}
+```
+
+```csharp
+.ConfigureMcpPipeline(mcp =>
+{
+  mcp
+    .WithTools<WeatherForecastTool>()
+    .WithPrompts<ForecastPrompts>();
+})
+```
+
+### Resources
+
+Decorate a class with `[McpServerResourceType]` and members with `[McpServerResource]`, then register with `WithResources<T>()`:
+
+```csharp
+using ModelContextProtocol.Server;
+
+[McpServerResourceType]
+public class ForecastResources
+{
+  [McpServerResource(Name = "current_forecast", Uri = "forecast://current")]
+  [Description("The current weather forecast as a structured list.")]
+  public static IEnumerable<WeatherForecast> CurrentForecast(IWeatherForecastService svc)
+  {
+    return svc.GetWeatherForecast();
+  }
+}
+```
+
+```csharp
+.ConfigureMcpPipeline(mcp =>
+{
+  mcp
+    .WithTools<WeatherForecastTool>()
+    .WithResources<ForecastResources>();
+})
+```
+
+DI injection into prompt and resource methods follows the same rules as tools: parameters typed as registered services are resolved from the DI container per-invocation.

--- a/hive.microservices/src/Hive.MicroServices/Extensions/IAppBuilderExtensions.cs
+++ b/hive.microservices/src/Hive.MicroServices/Extensions/IAppBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
 
 namespace Hive.MicroServices.Extensions;
 
@@ -7,6 +8,19 @@ namespace Hive.MicroServices.Extensions;
 /// </summary>
 public static class IAppBuilderExtensions
 {
+  /// <summary>
+  /// Drains all custom endpoint mapping actions registered via <c>MapEndpoints</c> onto the given <see cref="IEndpointRouteBuilder"/>.
+  /// </summary>
+  /// <param name="endpoints">The endpoint route builder</param>
+  /// <param name="service">The microservice whose <c>MapEndpointActions</c> are drained</param>
+  internal static void DrainCustomEndpoints(this IEndpointRouteBuilder endpoints, MicroService service)
+  {
+    foreach (var map in service.MapEndpointActions)
+    {
+      map(endpoints);
+    }
+  }
+
   /// <summary>
   /// Executes the action if the predicate is true
   /// </summary>

--- a/hive.microservices/src/Hive.MicroServices/Extensions/IMicroServiceExtensions.cs
+++ b/hive.microservices/src/Hive.MicroServices/Extensions/IMicroServiceExtensions.cs
@@ -173,6 +173,7 @@ public static class IMicroServiceExtensions
           app.UseAuthorization();
           app.UseEndpoints(endpoints =>
               {
+                endpoints.DrainCustomEndpoints(service);
                 endpoints.MapGet("/*", (ctx) =>
                     {
                       ctx.Response.StatusCode = 404;

--- a/hive.microservices/src/Hive.MicroServices/Extensions/IMicroServiceExtensions.cs
+++ b/hive.microservices/src/Hive.MicroServices/Extensions/IMicroServiceExtensions.cs
@@ -148,6 +148,15 @@ public static class IMicroServiceExtensions
   /// </summary>
   /// <param name="microservice"></param>
   /// <returns><see cref="IMicroService"/></returns>
+  /// <remarks>
+  /// Sets <see cref="MicroServicePipelineMode.None"/> on the service (bare service without an application
+  /// request-processing mode). Pipeline mode is set once; calling a second <c>Configure*Pipeline</c> method
+  /// on the same instance throws <see cref="InvalidOperationException"/> with message
+  /// <c>"MicroService PipelineMode is already set"</c>. Auxiliary HTTP routes can be added via
+  /// <c>MapEndpoints(...)</c> and are served before the built-in 404 catch-all, inside the same routing
+  /// and authorization envelope. This is the only <c>None</c>-mode pipeline that accepts
+  /// <c>MapEndpoints</c>; <c>ConfigureJob</c> (which also sets <c>None</c>) rejects custom routes at startup.
+  /// </remarks>
   public static IMicroService ConfigureDefaultServicePipeline(this IMicroService microservice)
   {
     var service = (MicroService)microservice;

--- a/hive.microservices/src/Hive.MicroServices/IMicroServiceMapEndpointsExtensions.cs
+++ b/hive.microservices/src/Hive.MicroServices/IMicroServiceMapEndpointsExtensions.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Routing;
+
+namespace Hive.MicroServices;
+
+/// <summary>
+/// Extension methods for registering auxiliary HTTP endpoints on an <see cref="IMicroService"/>.
+/// </summary>
+public static class IMicroServiceMapEndpointsExtensions
+{
+  /// <summary>
+  /// Registers auxiliary HTTP routes that are served inside the selected pipeline
+  /// mode's routing/CORS/authorization envelope, alongside the mode's own endpoints.
+  /// Mode-agnostic and additive; does not affect <see cref="MicroServicePipelineMode"/>.
+  /// </summary>
+  /// <param name="microservice">The microservice to configure</param>
+  /// <param name="map">A delegate that maps routes on the <see cref="IEndpointRouteBuilder"/></param>
+  /// <returns><see cref="IMicroService"/></returns>
+  /// <exception cref="ArgumentNullException">Thrown when any of the provided arguments are null</exception>
+  public static IMicroService MapEndpoints(
+    this IMicroService microservice,
+    Action<IEndpointRouteBuilder> map)
+  {
+    _ = microservice ?? throw new ArgumentNullException(nameof(microservice));
+    _ = map ?? throw new ArgumentNullException(nameof(map));
+
+    var service = (MicroService)microservice;
+    service.MapEndpointActions.Add(map);
+
+    return microservice;
+  }
+}

--- a/hive.microservices/src/Hive.MicroServices/MicroService.cs
+++ b/hive.microservices/src/Hive.MicroServices/MicroService.cs
@@ -5,6 +5,7 @@ using Hive.Exceptions;
 using Hive.Extensions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -103,6 +104,12 @@ public partial class MicroService : MicroServiceBase, IMicroService
   /// The microservice's list of actions executed during the pipeline configuration phase against the <see cref="IApplicationBuilder"/>
   /// </summary>
   internal List<Action<IApplicationBuilder>> ConfigurePipelineActions { get; } = new List<Action<IApplicationBuilder>>();
+
+  /// <summary>
+  /// The microservice's list of auxiliary endpoint mapping actions, drained by each HTTP mode's <c>UseEndpoints</c> block.
+  /// Populated by <see cref="IMicroServiceMapEndpointsExtensions.MapEndpoints"/>.
+  /// </summary>
+  internal List<Action<IEndpointRouteBuilder>> MapEndpointActions { get; } = new();
 
   internal Func<Assembly> MicroServiceEntrypointAssemblyProvider { get; set; } = () => Assembly.GetEntryAssembly()!;
 

--- a/hive.microservices/src/Hive.MicroServices/README.md
+++ b/hive.microservices/src/Hive.MicroServices/README.md
@@ -373,6 +373,73 @@ await microservice.InitializeAsync(config);
 var myService = microservice.ServiceProvider.GetRequiredService<IMyService>();
 ```
 
+## Constraints & Gotchas
+
+### One pipeline per service
+
+Pipeline modes are **mutually exclusive**. `PipelineMode` is set-once; calling a second `Configure*Pipeline`
+method on the same `MicroService` instance immediately throws:
+
+```
+InvalidOperationException: "MicroService PipelineMode is already set"
+```
+
+Starting a service without any pipeline call throws:
+
+```
+ConfigurationException: "No pipeline has been configured. Aborting"
+```
+
+### Choosing a pipeline mode
+
+| Method | Mode set | Use when |
+|---|---|---|
+| `ConfigureApiPipeline(endpoints => ...)` | `Api` | Minimal APIs (modern REST) |
+| `ConfigureApiControllerPipeline()` | `ApiControllers` | Controller-based REST APIs |
+| `ConfigureGraphQLPipeline(schema => ...)` | `GraphQL` | GraphQL APIs via HotChocolate |
+| `ConfigureGrpcPipeline(endpoints => ...)` | `Grpc` | Protobuf-first gRPC services |
+| `ConfigureCodeFirstGrpcPipeline(endpoints => ...)` | `Grpc` | Code-first gRPC services |
+| `ConfigureMcpPipeline(server => ...)` | `Mcp` | MCP servers (LLM tool/data servers) |
+| `ConfigureJob()` | `None` | Background workers, no HTTP application surface |
+| `ConfigureDefaultServicePipeline()` | `None` | Bare services with optional auxiliary HTTP routes |
+
+### The `MapEndpoints` seam
+
+`MapEndpoints(routes => ...)` adds auxiliary HTTP routes (control-plane endpoints, webhooks, admin actions)
+**alongside** any HTTP pipeline mode. Custom routes share the mode's `UseRouting → (UseCors) → UseAuthorization → UseEndpoints` envelope — authorization and CORS apply consistently, and mode endpoints are registered first.
+
+```csharp
+new MicroService("my-mcp-server")
+    .ConfigureMcpPipeline(server => server.WithTools<MyTools>())
+    .MapEndpoints(routes => routes.MapPost("/admin/flush", () => Results.Ok()));
+```
+
+`MapEndpoints` works with `Api`, `ApiControllers`, `GraphQL`, `Grpc`, `Mcp`, and `ConfigureDefaultServicePipeline`.
+It does **not** work with `ConfigureJob`: if any `MapEndpoints` calls are recorded, the Job pipeline throws
+`ConfigurationException` at startup:
+
+```
+"Hive.MicroServices.Job (worker) services cannot expose custom HTTP endpoints via MapEndpoints.
+Remove the MapEndpoints call, or select an HTTP pipeline mode (e.g. ConfigureApiPipeline / ConfigureGraphQLPipeline)."
+```
+
+See [custom_endpoints_seam_design.md](../../../../docs/design/custom_endpoints_seam_design.md) for the design rationale.
+
+### CORS is `IMicroService`-only
+
+The `CORS.Extension` (`WithCORS()`) requires an ASP.NET Core host (`IMicroService`). Its factory method
+`Extension.Create(...)` throws `InvalidOperationException` if the host is not an `IMicroService` — it cannot
+be used with `IFunctionHost` or other non-ASP.NET hosting models.
+
+### OpenTelemetry configuration
+
+`WithOpenTelemetry()` configures logging, tracing, and metrics via the `OpenTelemetry` configuration section
+in `IConfiguration`. Instrumentation (ASP.NET Core, HTTP client, runtime) and exporters (console, OTLP) are
+controlled by `appsettings.json` options — not by builder lambdas. The OTLP endpoint is resolved from
+`OpenTelemetry:Otlp:Endpoint` first, then from the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable.
+Activity sources from sibling extensions that implement `IActivitySourceProvider` (e.g. `Hive.Messaging`) are
+discovered and subscribed to automatically.
+
 ## Related Libraries
 
 - **[Hive.Abstractions](../../hive.core/src/Hive.Abstractions/)**: Core abstractions and interfaces

--- a/hive.microservices/tests/Hive.MicroServices.Tests/Hive.MicroServices.Tests.csproj
+++ b/hive.microservices/tests/Hive.MicroServices.Tests/Hive.MicroServices.Tests.csproj
@@ -29,6 +29,7 @@
     <ProjectReference Include="..\..\src\Hive.MicroServices.GraphQL\Hive.MicroServices.GraphQL.csproj" />
     <ProjectReference Include="..\..\src\Hive.MicroServices.Grpc\Hive.MicroServices.Grpc.csproj" />
     <ProjectReference Include="..\..\src\Hive.MicroServices.Job\Hive.MicroServices.Job.csproj" />
+    <ProjectReference Include="..\..\src\Hive.MicroServices.Mcp\Hive.MicroServices.Mcp.csproj" />
     <ProjectReference Include="..\..\src\Hive.MicroServices.Testing\Hive.MicroServices.Testing.csproj" />
   </ItemGroup>
 

--- a/hive.microservices/tests/Hive.MicroServices.Tests/MicroServiceTests.MapEndpoints.cs
+++ b/hive.microservices/tests/Hive.MicroServices.Tests/MicroServiceTests.MapEndpoints.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using CloudTek.Testing;
 using FluentAssertions;
 using Hive.Exceptions;
+using Hive.MicroServices.Api;
 using Hive.MicroServices.Extensions;
 using Hive.MicroServices.GraphQL;
 using Hive.MicroServices.Grpc;
@@ -423,6 +424,64 @@ public partial class MicroServiceTests
       // Assert — no exception; service starts
       await act.Should().NotThrowAsync();
       await microservice.StopAsync();
+    }
+
+    // ─── Integration: ApiControllers + custom route coexist ──────────────────
+
+    [Fact]
+    [IntegrationTest]
+    public async Task GivenApiControllerPipelineWithMapEndpoints_WhenRequesting_ThenControllerAndCustomRouteCoexist()
+    {
+      // Arrange
+      using var scope = EnvironmentVariableScope.Create(
+        Constants.EnvironmentVariables.DotNet.Environment, "Development");
+
+      var config = new ConfigurationBuilder().Build();
+
+      // ConfigureTestHost does not propagate WebHostDefaults.ApplicationKey (unlike RunAsync), so
+      // AddControllers() falls back to the test-runner entry assembly instead of the test project.
+      // We explicitly register the test assembly as an application part to make PingController discoverable.
+      await using var microservice = new MicroService(ServiceName, new NullLogger<IMicroService>())
+        .InTestClass<MicroServiceTests>()
+        .ConfigureServices((services, _) =>
+        {
+          services.AddControllers()
+            .AddApplicationPart(typeof(MicroServiceTests).Assembly);
+        })
+        .ConfigureApiControllerPipeline()
+        .MapEndpoints(routes =>
+        {
+          routes.MapGet("/admin/ping", () => Results.Ok(new { ping = "pong" }));
+        })
+        .ConfigureTestHost();
+
+      await microservice.InitializeAsync(config);
+      await microservice.StartAsync();
+
+      try
+      {
+        var server = ((MicroService)microservice).Host.GetTestServer();
+        var client = server.CreateClient();
+
+        // Act — controller route must respond
+        var controllerResponse = await client.GetAsync("/api/ping");
+
+        // Act — custom MapEndpoints route must also respond
+        var customResponse = await client.GetAsync("/admin/ping");
+
+        // Assert — both routes return 200
+        controllerResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var controllerContent = await controllerResponse.Content.ReadAsStringAsync();
+        controllerContent.Should().Contain("pong");
+
+        customResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var customContent = await customResponse.Content.ReadAsStringAsync();
+        customContent.Should().Contain("pong");
+      }
+      finally
+      {
+        await microservice.StopAsync();
+      }
     }
 
     // ─── Helper types ─────────────────────────────────────────────────────────

--- a/hive.microservices/tests/Hive.MicroServices.Tests/MicroServiceTests.MapEndpoints.cs
+++ b/hive.microservices/tests/Hive.MicroServices.Tests/MicroServiceTests.MapEndpoints.cs
@@ -1,0 +1,442 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using CloudTek.Testing;
+using FluentAssertions;
+using Hive.Exceptions;
+using Hive.MicroServices.Extensions;
+using Hive.MicroServices.GraphQL;
+using Hive.MicroServices.Grpc;
+using Hive.MicroServices.Job;
+using Hive.MicroServices.Mcp;
+using Hive.MicroServices.Testing;
+using Hive.Testing;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Hive.MicroServices.Tests;
+
+public partial class MicroServiceTests
+{
+  public class MapEndpointsTests
+  {
+    private const string ServiceName = "microservice-tests-map-endpoints";
+
+    // ─── Unit: recorder ──────────────────────────────────────────────────────
+
+    [Fact]
+    [UnitTest]
+    public void GivenMapEndpoints_WhenCalledWithValidArgs_ThenActionIsAppended()
+    {
+      // Arrange
+      var microservice = new MicroService(ServiceName, new NullLogger<IMicroService>());
+
+      // Act
+      microservice.MapEndpoints(endpoints => endpoints.MapGet("/test", () => Results.Ok()));
+
+      // Assert
+      ((MicroService)microservice).MapEndpointActions.Should().HaveCount(1);
+    }
+
+    [Fact]
+    [UnitTest]
+    public void GivenMapEndpoints_WhenCalledMultipleTimes_ThenAllActionsAreAppended()
+    {
+      // Arrange
+      var microservice = new MicroService(ServiceName, new NullLogger<IMicroService>());
+
+      // Act
+      microservice
+        .MapEndpoints(endpoints => endpoints.MapGet("/a", () => Results.Ok()))
+        .MapEndpoints(endpoints => endpoints.MapGet("/b", () => Results.Ok()));
+
+      // Assert
+      ((MicroService)microservice).MapEndpointActions.Should().HaveCount(2);
+    }
+
+    [Fact]
+    [UnitTest]
+    public void GivenMapEndpoints_WhenMicroserviceIsNull_ThenThrowsArgumentNullException()
+    {
+      // Arrange
+      IMicroService? microservice = null;
+
+      // Act
+      var act = () => microservice!.MapEndpoints(endpoints => { });
+
+      // Assert
+      act.Should().Throw<ArgumentNullException>().WithParameterName("microservice");
+    }
+
+    [Fact]
+    [UnitTest]
+    public void GivenMapEndpoints_WhenMapIsNull_ThenThrowsArgumentNullException()
+    {
+      // Arrange
+      IMicroService microservice = new MicroService(ServiceName, new NullLogger<IMicroService>());
+
+      // Act
+      var act = () => microservice.MapEndpoints(null!);
+
+      // Assert
+      act.Should().Throw<ArgumentNullException>().WithParameterName("map");
+    }
+
+    [Fact]
+    [UnitTest]
+    public void GivenMapEndpoints_WhenCalled_ThenDoesNotInspectPipelineMode()
+    {
+      // Arrange — no pipeline configured, PipelineMode is NotSet
+      var microservice = new MicroService(ServiceName, new NullLogger<IMicroService>());
+
+      // Act — must not throw regardless of PipelineMode
+      var act = () => microservice.MapEndpoints(endpoints => { });
+
+      // Assert
+      act.Should().NotThrow();
+      ((MicroService)microservice).PipelineMode.Should().Be(MicroServicePipelineMode.NotSet);
+    }
+
+    // ─── Integration: MCP + custom route share DI singleton ──────────────────
+
+    [Fact]
+    [IntegrationTest]
+    public async Task GivenMcpPipelineWithMapEndpoints_WhenRequesting_ThenCustomRouteResponds()
+    {
+      // Arrange
+      using var scope = EnvironmentVariableScope.Create(
+        Constants.EnvironmentVariables.DotNet.Environment, "Development");
+
+      var config = new ConfigurationBuilder().Build();
+
+      await using var microservice = new MicroService(ServiceName, new NullLogger<IMicroService>())
+        .InTestClass<MicroServiceTests>()
+        .ConfigureServices((services, _) =>
+        {
+          services.AddSingleton<SharedCounter>();
+        })
+        .ConfigureMcpPipeline(mcp => { })
+        .MapEndpoints(routes =>
+        {
+          routes.MapPost("/admin/flush", (SharedCounter counter) =>
+          {
+            counter.Increment();
+            return Results.Ok(new { flushed = counter.Value });
+          });
+        })
+        .ConfigureTestHost();
+
+      await microservice.InitializeAsync(config);
+      await microservice.StartAsync();
+
+      try
+      {
+        var server = ((MicroService)microservice).Host.GetTestServer();
+        var client = server.CreateClient();
+
+        // Act — custom route must respond
+        var response = await client.PostAsync("/admin/flush", null);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var content = await response.Content.ReadAsStringAsync();
+        content.Should().Contain("flushed");
+      }
+      finally
+      {
+        await microservice.StopAsync();
+      }
+    }
+
+    [Fact]
+    [IntegrationTest]
+    public async Task GivenMcpPipelineWithMapEndpoints_WhenCustomRouteUsedSingleton_ThenSameInstanceAsFromDi()
+    {
+      // Arrange
+      using var scope = EnvironmentVariableScope.Create(
+        Constants.EnvironmentVariables.DotNet.Environment, "Development");
+
+      var config = new ConfigurationBuilder().Build();
+
+      SharedCounter? capturedFromEndpoint = null;
+
+      await using var microservice = new MicroService(ServiceName, new NullLogger<IMicroService>())
+        .InTestClass<MicroServiceTests>()
+        .ConfigureServices((services, _) =>
+        {
+          services.AddSingleton<SharedCounter>();
+        })
+        .ConfigureMcpPipeline(mcp => { })
+        .MapEndpoints(routes =>
+        {
+          routes.MapGet("/admin/counter", (SharedCounter counter) =>
+          {
+            capturedFromEndpoint = counter;
+            return Results.Ok(new { value = counter.Value });
+          });
+        })
+        .ConfigureTestHost();
+
+      await microservice.InitializeAsync(config);
+      await microservice.StartAsync();
+
+      try
+      {
+        var server = ((MicroService)microservice).Host.GetTestServer();
+        var client = server.CreateClient();
+
+        // Act — resolve via HTTP (triggers DI)
+        var response = await client.GetAsync("/admin/counter");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Also resolve directly from service provider — must be the same singleton
+        var concrete = (MicroService)microservice;
+        var fromDi = concrete.ServiceProvider.GetRequiredService<SharedCounter>();
+
+        // Assert — same instance (singleton)
+        capturedFromEndpoint.Should().NotBeNull();
+        capturedFromEndpoint.Should().BeSameAs(fromDi);
+      }
+      finally
+      {
+        await microservice.StopAsync();
+      }
+    }
+
+    // ─── Integration: GraphQL spot-check ─────────────────────────────────────
+
+    [Fact]
+    [IntegrationTest]
+    public async Task GivenGraphQLPipelineWithMapEndpoints_WhenCustomRouteRequested_ThenRespondsOk()
+    {
+      // Arrange
+      using var scope = EnvironmentVariableScope.Create(
+        Constants.EnvironmentVariables.DotNet.Environment, "Development");
+
+      var config = new ConfigurationBuilder().Build();
+
+      await using var microservice = new MicroService(ServiceName, new NullLogger<IMicroService>())
+        .InTestClass<MicroServiceTests>()
+        .ConfigureGraphQLPipeline(schema =>
+        {
+          schema.AddDocumentFromString("type Query { ping: String }");
+          schema.AddResolver("Query", "ping", _ => "pong");
+        })
+        .MapEndpoints(routes =>
+        {
+          routes.MapGet("/admin/ping", () => Results.Ok(new { ping = "pong" }));
+        })
+        .ConfigureTestHost();
+
+      await microservice.InitializeAsync(config);
+      await microservice.StartAsync();
+
+      try
+      {
+        var server = ((MicroService)microservice).Host.GetTestServer();
+        var client = server.CreateClient();
+
+        // Act — custom route must respond 200
+        var pingResponse = await client.GetAsync("/admin/ping");
+
+        // Assert
+        pingResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var content = await pingResponse.Content.ReadAsStringAsync();
+        content.Should().Contain("pong");
+      }
+      finally
+      {
+        await microservice.StopAsync();
+      }
+    }
+
+    // ─── Integration: gRPC catch-all ordering ────────────────────────────────
+
+    [Fact]
+    [IntegrationTest]
+    public async Task GivenGrpcPipelineWithMapEndpoints_WhenRequesting_ThenCustomRouteRespondsAndCatchAllStaysLast()
+    {
+      // Arrange
+      using var scope = EnvironmentVariableScope.Create(
+        Constants.EnvironmentVariables.DotNet.Environment, "Development");
+
+      var config = new ConfigurationBuilder().Build();
+
+      await using var microservice = new MicroService(ServiceName, new NullLogger<IMicroService>())
+        .InTestClass<MicroServiceTests>()
+        .ConfigureGrpcPipeline(endpoints => { })
+        .MapEndpoints(routes =>
+        {
+          routes.MapGet("/healthz-custom", () => Results.Ok(new { status = "healthy" }));
+        })
+        .ConfigureTestHost();
+
+      await microservice.InitializeAsync(config);
+      await microservice.StartAsync();
+
+      try
+      {
+        var server = ((MicroService)microservice).Host.GetTestServer();
+        var client = server.CreateClient();
+
+        // Act — custom route must resolve
+        var customResponse = await client.GetAsync("/healthz-custom");
+        customResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Act — gRPC catch-all must still return its guidance string (remains last)
+        var catchAllResponse = await client.GetAsync("/");
+        catchAllResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var catchAllContent = await catchAllResponse.Content.ReadAsStringAsync();
+        catchAllContent.Should().Contain("gRPC client");
+      }
+      finally
+      {
+        await microservice.StopAsync();
+      }
+    }
+
+    // ─── Integration: Default-None drains custom routes ──────────────────────
+
+    [Fact]
+    [IntegrationTest]
+    public async Task GivenDefaultServicePipelineWithMapEndpoints_WhenRequesting_ThenCustomRouteResponds()
+    {
+      // Arrange
+      using var scope = EnvironmentVariableScope.Create(
+        Constants.EnvironmentVariables.DotNet.Environment, "Development");
+
+      var config = new ConfigurationBuilder().Build();
+
+      await using var microservice = new MicroService(ServiceName, new NullLogger<IMicroService>())
+        .InTestClass<MicroServiceTests>()
+        .ConfigureDefaultServicePipeline()
+        .MapEndpoints(routes =>
+        {
+          routes.MapGet("/admin/ping", () => Results.Ok(new { ping = "pong" }));
+        })
+        .ConfigureTestHost();
+
+      await microservice.InitializeAsync(config);
+      await microservice.StartAsync();
+
+      try
+      {
+        var server = ((MicroService)microservice).Host.GetTestServer();
+        var client = server.CreateClient();
+
+        // Act — custom route must respond 200
+        var customResponse = await client.GetAsync("/admin/ping");
+        customResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Act — unmapped path must still return 404 via catch-all
+        var notFoundResponse = await client.GetAsync("/does-not-exist");
+        notFoundResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
+      }
+      finally
+      {
+        await microservice.StopAsync();
+      }
+    }
+
+    // ─── Integration: Job rejection ──────────────────────────────────────────
+
+    [Fact]
+    [IntegrationTest]
+    public async Task GivenJobPipeline_WhenMapEndpointsCalledAfterConfigureJob_ThenThrowsConfigurationException()
+    {
+      // Arrange — MapEndpoints AFTER ConfigureJob
+      using var scope = EnvironmentVariableScope.Create(
+        Constants.EnvironmentVariables.DotNet.Environment, "Development");
+
+      var config = new ConfigurationBuilder().Build();
+
+      await using var microservice = new MicroService(ServiceName, new NullLogger<IMicroService>())
+        .InTestClass<MicroServiceTests>()
+        .ConfigureJob()
+        .MapEndpoints(routes => routes.MapGet("/admin/ping", () => Results.Ok()))
+        .ConfigureTestHost();
+
+      // Act
+      var act = async () =>
+      {
+        await microservice.InitializeAsync(config);
+        await microservice.StartAsync();
+      };
+
+      // Assert
+      var ex = await act.Should().ThrowAsync<ConfigurationException>();
+      ex.And.Message.Should().Be(Constants.Errors.MapEndpointsJobForbidden);
+    }
+
+    [Fact]
+    [IntegrationTest]
+    public async Task GivenJobPipeline_WhenMapEndpointsCalledBeforeConfigureJob_ThenThrowsConfigurationException()
+    {
+      // Arrange — MapEndpoints BEFORE ConfigureJob (proves guard is at build time)
+      using var scope = EnvironmentVariableScope.Create(
+        Constants.EnvironmentVariables.DotNet.Environment, "Development");
+
+      var config = new ConfigurationBuilder().Build();
+
+      await using var microservice = new MicroService(ServiceName, new NullLogger<IMicroService>())
+        .InTestClass<MicroServiceTests>()
+        .MapEndpoints(routes => routes.MapGet("/admin/ping", () => Results.Ok()))
+        .ConfigureJob()
+        .ConfigureTestHost();
+
+      // Act
+      var act = async () =>
+      {
+        await microservice.InitializeAsync(config);
+        await microservice.StartAsync();
+      };
+
+      // Assert — same exception regardless of call order
+      var ex = await act.Should().ThrowAsync<ConfigurationException>();
+      ex.And.Message.Should().Be(Constants.Errors.MapEndpointsJobForbidden);
+    }
+
+    [Fact]
+    [IntegrationTest]
+    public async Task GivenJobPipeline_WhenNoMapEndpointsCalled_ThenServiceStartsNormally()
+    {
+      // Arrange — Job with NO MapEndpoints (negative case)
+      using var scope = EnvironmentVariableScope.Create(
+        Constants.EnvironmentVariables.DotNet.Environment, "Development");
+
+      var config = new ConfigurationBuilder().Build();
+
+      await using var microservice = new MicroService(ServiceName, new NullLogger<IMicroService>())
+        .InTestClass<MicroServiceTests>()
+        .ConfigureJob()
+        .ConfigureTestHost();
+
+      // Act
+      await microservice.InitializeAsync(config);
+      var act = async () => await microservice.StartAsync();
+
+      // Assert — no exception; service starts
+      await act.Should().NotThrowAsync();
+      await microservice.StopAsync();
+    }
+
+    // ─── Helper types ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Shared singleton used to prove DI instance identity across MCP tools and custom endpoints.
+    /// </summary>
+    internal sealed class SharedCounter
+    {
+      private int _value;
+
+      public int Value => _value;
+
+      public void Increment() => System.Threading.Interlocked.Increment(ref _value);
+    }
+  }
+}

--- a/hive.microservices/tests/Hive.MicroServices.Tests/TestData.PingController.cs
+++ b/hive.microservices/tests/Hive.MicroServices.Tests/TestData.PingController.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Hive.MicroServices.Tests;
+
+[ApiController]
+[Route("api/[controller]")]
+public sealed class PingController : ControllerBase
+{
+  [HttpGet]
+  public IActionResult Get() => Ok(new { ping = "pong" });
+}


### PR DESCRIPTION
## Summary

10.2.0 milestone PR. Ships the general-purpose **`MapEndpoints` seam** (issue [#64](https://github.com/cloud-tek/hive/issues/64) "main") **and** the **#65 documentation set** that documents it, folded together (the docs depend on the feature's code).

Design gate: **ADR `docs/design/custom_endpoints_seam_design.md`** (Accepted).

## Feature — `MapEndpoints` (#64)
```csharp
public static IMicroService MapEndpoints(this IMicroService microservice, Action<IEndpointRouteBuilder> map)
```
Mode-agnostic, additive, call-order-independent. Lets any HTTP pipeline mode (Api, ApiControllers, GraphQL, Grpc, Mcp, Default/None) expose auxiliary routes (control-plane, webhooks, admin) inside the mode's own `UseRouting → CORS → UseAuthorization → UseEndpoints` envelope — retiring the fragile `RegisterExtension` + `Configure(app)` workaround.

- Mode endpoints first, custom routes drained after (gRPC drains before its catch-all).
- **Job/worker services are forbidden** custom HTTP routes — enforced at pipeline-build time (call-order-independent) via `ConfigurationException`.
- **Default (`None`) services drain** custom routes. (Both Job and Default are `PipelineMode.None`; the split lives in the two build delegates, never an enum check — a test asserts Job throws in both call orders so this can't silently regress. See ADR §11.)
- Demo: `Hive.MicroServices.Demo.Mcp` shows a custom `POST /admin/...` sharing a DI singleton with an MCP tool.

## Documentation (#65)
- **P0** — XML `<remarks>` on every `Configure*Pipeline` method (set-once invariant, exact exception, MapEndpoints coexistence + Job prohibition); core framework README "Constraints & Gotchas" (mode selection, the seam, CORS `IMicroService`-only, OpenTelemetry semantics).
- **P1** — new `Hive.MicroServices.Mcp/README.md` (quickstart, tool registration, transport, prompts/resources, coexistence via the seam), modeled on the Hive.HTTP README.
- **P2** — `docs/README.md` index + `docs/getting-started.md` + `docs/build.md`, cross-linked from the root and module READMEs; resolves the ADR's docs-index reference.

## Tests — 63/63 green
5 recorder unit tests + 8 TestServer integration tests across MCP, GraphQL, gRPC, **MVC controllers** (controller + custom route coexist), Default-`None`, and Job rejection (both call orders + negative case).

## Verification
- Full `cloudtek-build --target All`: **all targets green** (Format/Analyzer checks, Compile, Unit + Integration, Pack).
- `Version.targets`: `10.1.1 → 10.2.0`.

## Follow-ups (tracked separately)
- [#70](https://github.com/cloud-tek/hive/issues/70) — `ConfigureTestHost` ApplicationKey gap (controller tests currently need an explicit `AddApplicationPart`; out of scope here).
- ADR §11 deferred: give the Job-forbids-HTTP guard an enum-anchored home (dedicated `Job` pipeline value / flag).

## Reviewer notes
- The plan listed #65 as separate PRs (PR-4/5/6); folded into this PR by request since the docs document this PR's feature.
- GraphQL doc/test scope: the spot-check verifies the custom route is served in GraphQL mode (the seam's goal).
- An OpenTelemetry doc discrepancy was found: the `.WithOpenTelemetry(...)` lambda signature in `.claude/rules/opentelemetry.md` does not match the shipped extension (which takes `additionalActivitySources`). The README documents actual behavior; the rule file is stale and worth a separate fix.