### PR TITLE
ci: bump cloud-tek/.github reusable workflows to v0.4.0 (fix Dagger engine pull)

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build:
-    uses: cloud-tek/.github/.github/workflows/dagger-cloudtek-build.yml@v0.3.0
+    uses: cloud-tek/.github/.github/workflows/dagger-cloudtek-build.yml@v0.4.0
     name: build
     with:
       directory: .
@@ -37,7 +37,7 @@ jobs:
       DAGGER_SSH_PRIVATE_KEY: '${{ secrets.DAGGER_SSH_PRIVATE_KEY }}'
 
   push:
-    uses: cloud-tek/.github/.github/workflows/dotnet-push.yml@v0.3.0
+    uses: cloud-tek/.github/.github/workflows/dotnet-push.yml@v0.4.0
     name: push
     needs: build
     if: |


### PR DESCRIPTION
## Summary

Bumps the `cloud-tek/.github` reusable workflow refs `v0.3.0 → v0.4.0` in [.github/workflows/dotnet-build.yml](.github/workflows/dotnet-build.yml) to pick up the **authenticated Dagger engine-image pull** ([cloud-tek/.github#1](https://github.com/cloud-tek/.github/pull/1)).

## Why

The `build` workflow on `main` was failing consistently with the Dagger engine failing to provision:

```
Get "https://registry.dagger.io/v2/": net/http: request canceled (Client.Timeout exceeded while awaiting headers)
```

Root cause: `registry.dagger.io` is a Fly.io proxy fronting `ghcr.io`, and the engine image was pulled **anonymously** — anonymous pulls from GitHub Actions' shared runner egress IPs get rate-limited/tarpitted. The fix (in the reusable workflow, released as `v0.4.0`) authenticates the pull with `GH_TOKEN`, which the proxy passes through to ghcr.io.

## Changes

- `dagger-cloudtek-build.yml@v0.3.0 → @v0.4.0`
- `dotnet-push.yml@v0.3.0 → @v0.4.0`
- `dagger-module` ref unchanged (`@refs/tags/v0.3.2`).

## Notes

- This is the consumer-side half of the two-repo fix; the engine-pull change merged in cloud-tek/.github#1 and was tagged `v0.4.0`.
- Merging this should turn the `build` workflow green again (the throttling fix takes effect on the next run).
- Longer-term hardening (hosted/remote Dagger engine to drop the local pull entirely) is tracked in cloud-tek/.github#2.