### PR TITLE
Revert "ci: bump cloud-tek/.github reusable workflows to v0.4.0"

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build:
-    uses: cloud-tek/.github/.github/workflows/dagger-cloudtek-build.yml@v0.4.0
+    uses: cloud-tek/.github/.github/workflows/dagger-cloudtek-build.yml@v0.3.0
     name: build
     with:
       directory: .
@@ -37,7 +37,7 @@ jobs:
       DAGGER_SSH_PRIVATE_KEY: '${{ secrets.DAGGER_SSH_PRIVATE_KEY }}'
 
   push:
-    uses: cloud-tek/.github/.github/workflows/dotnet-push.yml@v0.4.0
+    uses: cloud-tek/.github/.github/workflows/dotnet-push.yml@v0.3.0
     name: push
     needs: build
     if: |


### PR DESCRIPTION
Reverts #73. The v0.4.0 authenticated-pull change does not fix the build: the runner cannot reach `registry.dagger.io` at all (the `docker login` step times out on the initial `GET /v2/` before any credentials are exchanged), so authentication is irrelevant — it's a runner↔registry connectivity issue, not rate-limiting. Reverting to v0.3.0 to restore a clean baseline pending a new approach (avoiding registry.dagger.io entirely).