### PR TITLE
ci: adopt cloud-tek/.github v0.4.0 (Dagger engine from ghcr mirror)

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build:
-    uses: cloud-tek/.github/.github/workflows/dagger-cloudtek-build.yml@v0.3.0
+    uses: cloud-tek/.github/.github/workflows/dagger-cloudtek-build.yml@v0.4.0
     name: build
     with:
       directory: .
@@ -37,7 +37,7 @@ jobs:
       DAGGER_SSH_PRIVATE_KEY: '${{ secrets.DAGGER_SSH_PRIVATE_KEY }}'
 
   push:
-    uses: cloud-tek/.github/.github/workflows/dotnet-push.yml@v0.3.0
+    uses: cloud-tek/.github/.github/workflows/dotnet-push.yml@v0.4.0
     name: push
     needs: build
     if: |


### PR DESCRIPTION
Bumps the reusable workflow refs `v0.3.0 → v0.4.0`. v0.4.0 (cloud-tek/.github#4) provisions the Dagger engine from `ghcr.io/cloud-tek/dagger-engine` (reachable) instead of the unreachable `registry.dagger.io`, fixing the engine-provisioning timeouts that were failing the build on `main`. Validation: the post-merge push-to-main build (which does not run the publish job).