### PR TITLE
Revert to cloud-tek/.github v0.3.0 (registry.dagger.io outage cleared)

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build:
-    uses: cloud-tek/.github/.github/workflows/dagger-cloudtek-build.yml@v0.4.0
+    uses: cloud-tek/.github/.github/workflows/dagger-cloudtek-build.yml@v0.3.0
     name: build
     with:
       directory: .
@@ -37,7 +37,7 @@ jobs:
       DAGGER_SSH_PRIVATE_KEY: '${{ secrets.DAGGER_SSH_PRIVATE_KEY }}'
 
   push:
-    uses: cloud-tek/.github/.github/workflows/dotnet-push.yml@v0.4.0
+    uses: cloud-tek/.github/.github/workflows/dotnet-push.yml@v0.3.0
     name: push
     needs: build
     if: |


### PR DESCRIPTION
Reverts the v0.4.0 ghcr-mirror adoption (#75). The registry.dagger.io connectivity issue that motivated the mirror was **transient** and has cleared — the v0.3.0 build succeeded again at 09:50 (#27944215625, dagger call ✓, pulling the engine from registry.dagger.io). Reverting to v0.3.0 restores a green main now. The ghcr mirror (image, cloud-tek/.github v0.4.0 tag, the prime-from-ghcr workflow) is kept intact as a ready fallback should the outage recur; re-adopting it just needs the internal-package token access sorted (CLOUDTEK_AUTOMATION_TOKEN org membership + read:packages).